### PR TITLE
refactor: change properties type to map[string][string]

### DIFF
--- a/container/connection_plugin_chain_builder.go
+++ b/container/connection_plugin_chain_builder.go
@@ -44,7 +44,7 @@ type ConnectionPluginChainBuilder struct {
 func (builder *ConnectionPluginChainBuilder) GetPlugins(
 	pluginService *driver_infrastructure.PluginService,
 	pluginManager *driver_infrastructure.PluginManager,
-	props map[string]any) ([]*driver_infrastructure.ConnectionPlugin, error) {
+	props map[string]string) ([]*driver_infrastructure.ConnectionPlugin, error) {
 	var resultPlugins []*driver_infrastructure.ConnectionPlugin
 	var pluginFactoryFuncWeights []PluginFactoryFuncWeight
 	usingDefault := false

--- a/container/container.go
+++ b/container/container.go
@@ -19,6 +19,7 @@ package container
 import (
 	"awssql/driver_infrastructure"
 	"awssql/plugin_helpers"
+	"awssql/utils"
 	"database/sql/driver"
 )
 
@@ -28,7 +29,10 @@ type Container struct {
 }
 
 func NewContainer(dsn string, targetDriver driver.Driver) (Container, error) {
-	props := driver_infrastructure.PropertiesFromDsn(dsn)
+	props, parseErr := utils.ParseDsn(dsn)
+	if parseErr != nil {
+		return Container{}, parseErr
+	}
 	defaultConnProvider := driver_infrastructure.ConnectionProvider(driver_infrastructure.NewDriverConnectionProvider(targetDriver))
 
 	pluginManager := driver_infrastructure.PluginManager(plugin_helpers.NewPluginManagerImpl(targetDriver, &defaultConnProvider, nil, props))

--- a/driver_infrastructure/aws_wrapper_property.go
+++ b/driver_infrastructure/aws_wrapper_property.go
@@ -16,15 +16,26 @@
 
 package driver_infrastructure
 
+import "strconv"
+
 const DEFAULT_PLUGINS = ""
 
+type WrapperPropertyType int
+
+const (
+	WRAPPER_TYPE_INT    WrapperPropertyType = 1
+	WRAPPER_TYPE_STRING WrapperPropertyType = 2
+	WRAPPER_TYPE_BOOL   WrapperPropertyType = 3
+)
+
 type AwsWrapperProperty struct {
-	Name         string
-	description  string
-	defaultValue any
+	Name                string
+	description         string
+	defaultValue        string
+	wrapperPropertyType WrapperPropertyType
 }
 
-func (prop *AwsWrapperProperty) Get(props map[string]any) any {
+func (prop *AwsWrapperProperty) Get(props map[string]string) string {
 	var result, ok = props[prop.Name]
 	if !ok {
 		return prop.defaultValue
@@ -32,19 +43,43 @@ func (prop *AwsWrapperProperty) Get(props map[string]any) any {
 	return result
 }
 
-func (prop *AwsWrapperProperty) Set(props map[string]any, val any) {
+func (prop *AwsWrapperProperty) Set(props map[string]string, val string) {
 	props[prop.Name] = val
+}
+
+func GetVerifiedWrapperPropertyValue[T any](props map[string]string, property AwsWrapperProperty) T {
+	propValue := property.Get(props)
+	var parsedValue any
+	switch property.wrapperPropertyType {
+	case WRAPPER_TYPE_INT:
+		parsedValue, _ = strconv.Atoi(propValue)
+	case WRAPPER_TYPE_STRING:
+		parsedValue = propValue
+	case WRAPPER_TYPE_BOOL:
+		parsedValue, _ = strconv.ParseBool(propValue)
+	default:
+		panic(GetMessage("AwsWrapperProperty.invalidPropertyType", property.Name, property.wrapperPropertyType))
+	}
+
+	result, ok := parsedValue.(T)
+	if !ok {
+		panic(GetMessage("AwsWrapperProperty.unexpectedType", property.Name, propValue))
+	}
+
+	return result
 }
 
 var PLUGINS = AwsWrapperProperty{
 	"plugins",
 	"Comma separated list of connection plugin codes.",
 	DEFAULT_PLUGINS,
+	WRAPPER_TYPE_STRING,
 }
 
 var AUTO_SORT_PLUGIN_ORDER = AwsWrapperProperty{
 	"autoSortPluginOrder",
 	"This flag is enabled by default, meaning that the plugins order will be automatically adjusted. Disable it at your own " +
 		"risk or if you really need plugins to be executed in a particular order.",
-	true,
+	"true",
+	WRAPPER_TYPE_BOOL,
 }

--- a/driver_infrastructure/connection_plugin.go
+++ b/driver_infrastructure/connection_plugin.go
@@ -26,12 +26,11 @@ type ConnectionPlugin interface {
 		methodName string,
 		executeFunc ExecuteFunc,
 		methodArgs ...any) (wrappedReturnValue any, wrappedReturnValue2 any, wrappedOk bool, wrappedErr error)
-	Connect(hostInfo HostInfo, properties map[string]any, isInitialConnection bool, connectFunc ConnectFunc) (driver.Conn, error)
-	ForceConnect(hostInfo HostInfo, properties map[string]any, isInitialConnection bool, connectFunc ConnectFunc) (driver.Conn, error)
+	Connect(hostInfo HostInfo, props map[string]string, isInitialConnection bool, connectFunc ConnectFunc) (driver.Conn, error)
+	ForceConnect(hostInfo HostInfo, props map[string]string, isInitialConnection bool, connectFunc ConnectFunc) (driver.Conn, error)
 	AcceptsStrategy(role HostRole, strategy string) bool
 	GetHostInfoByStrategy(role HostRole, strategy string, hosts []HostInfo) (HostInfo, error)
 	NotifyConnectionChanged(changes map[HostChangeOptions]bool) OldConnectionSuggestedAction
 	NotifyHostListChanged(changes map[string]map[HostChangeOptions]bool)
-	InitHostProvider(
-		initialUrl string, props map[string]any, hostListProviderService HostListProviderService, initHostProviderFunc func() error) error
+	InitHostProvider(initialUrl string, props map[string]string, hostListProviderService HostListProviderService, initHostProviderFunc func() error) error
 }

--- a/driver_infrastructure/connection_plugin_factory.go
+++ b/driver_infrastructure/connection_plugin_factory.go
@@ -17,5 +17,5 @@
 package driver_infrastructure
 
 type ConnectionPluginFactory interface {
-	GetInstance(pluginService *PluginService, properties map[string]any) (*ConnectionPlugin, error)
+	GetInstance(pluginService *PluginService, props map[string]string) (*ConnectionPlugin, error)
 }

--- a/driver_infrastructure/connection_provider.go
+++ b/driver_infrastructure/connection_provider.go
@@ -21,8 +21,8 @@ import (
 )
 
 type ConnectionProvider interface {
-	AcceptsUrl(hostInfo HostInfo, properties map[string]any) bool
+	AcceptsUrl(hostInfo HostInfo, props map[string]string) bool
 	AcceptsStrategy(role HostRole, strategy string) bool
-	GetHostInfoByStrategy(hosts []HostInfo, role HostRole, strategy string, properties map[string]any) (HostInfo, error)
-	Connect(hostInfo HostInfo, properties map[string]any) (driver.Conn, error)
+	GetHostInfoByStrategy(hosts []HostInfo, role HostRole, strategy string, props map[string]string) (HostInfo, error)
+	Connect(hostInfo HostInfo, props map[string]string, pluginService *PluginService) (driver.Conn, error)
 }

--- a/driver_infrastructure/connection_provider_manager.go
+++ b/driver_infrastructure/connection_provider_manager.go
@@ -23,8 +23,8 @@ type ConnectionProviderManager struct {
 
 func (connProviderManager *ConnectionProviderManager) GetConnectionProvider(
 	hostInfo HostInfo,
-	properties map[string]any) *ConnectionProvider {
-	if connProviderManager.effectiveProvider != nil && (*connProviderManager.effectiveProvider).AcceptsUrl(hostInfo, properties) {
+	props map[string]string) *ConnectionProvider {
+	if connProviderManager.effectiveProvider != nil && (*connProviderManager.effectiveProvider).AcceptsUrl(hostInfo, props) {
 		return connProviderManager.effectiveProvider
 	}
 
@@ -47,13 +47,13 @@ func (connProviderManager *ConnectionProviderManager) GetHostInfoByStrategy(
 	hosts []HostInfo,
 	role HostRole,
 	strategy string,
-	properties map[string]any) (HostInfo, error) {
+	props map[string]string) (HostInfo, error) {
 	if (*connProviderManager.effectiveProvider).AcceptsStrategy(role, strategy) {
-		host, err := (*connProviderManager.effectiveProvider).GetHostInfoByStrategy(hosts, role, strategy, properties)
+		host, err := (*connProviderManager.effectiveProvider).GetHostInfoByStrategy(hosts, role, strategy, props)
 		if err == nil {
 			return host, err
 		}
 	}
 
-	return (*connProviderManager.defaultProvider).GetHostInfoByStrategy(hosts, role, strategy, properties)
+	return (*connProviderManager.defaultProvider).GetHostInfoByStrategy(hosts, role, strategy, props)
 }

--- a/driver_infrastructure/host_selector.go
+++ b/driver_infrastructure/host_selector.go
@@ -21,5 +21,5 @@ const (
 )
 
 type HostSelector interface {
-	GetHost(hosts []HostInfo, role HostRole, props map[string]any) (HostInfo, error)
+	GetHost(hosts []HostInfo, role HostRole, props map[string]string) (HostInfo, error)
 }

--- a/driver_infrastructure/plugin_helpers.go
+++ b/driver_infrastructure/plugin_helpers.go
@@ -39,8 +39,8 @@ type PluginService interface {
 	GetHostListProvider() HostListProvider
 	RefreshHostList(conn driver.Conn) error
 	ForceRefreshHostList(conn driver.Conn) error // TODO: double check signatures, there are multiple
-	Connect(hostInfo HostInfo, props map[string]any) (driver.Conn, error)
-	ForceConnect(hostInfo HostInfo, props map[string]any) (driver.Conn, error)
+	Connect(hostInfo HostInfo, props map[string]string) (driver.Conn, error)
+	ForceConnect(hostInfo HostInfo, props map[string]string) (driver.Conn, error)
 	GetDialect() DatabaseDialect
 	UpdateDialect(conn driver.Conn)
 	GetTargetDriverDialect() TargetDriverDialect
@@ -48,14 +48,14 @@ type PluginService interface {
 	FillAliases(conn driver.Conn, hostInfo HostInfo) error
 	GetHostInfoBuilder() HostInfoBuilder
 	GetConnectionProvider() ConnectionProvider
-	GetProperties() map[string]any
+	GetProperties() map[string]string
 }
 
 type PluginManager interface {
-	Init(pluginService *PluginService, props map[string]any, plugins []*ConnectionPlugin) error
-	InitHostProvider(initialUrl string, props map[string]any, hostListProviderService HostListProviderService) error
-	Connect(hostInfo HostInfo, props map[string]any, isInitialConnection bool) (driver.Conn, error)
-	ForceConnect(hostInfo HostInfo, props map[string]any, isInitialConnection bool) (driver.Conn, error)
+	Init(pluginService *PluginService, props map[string]string, plugins []*ConnectionPlugin) error
+	InitHostProvider(initialUrl string, props map[string]string, hostListProviderService HostListProviderService) error
+	Connect(hostInfo HostInfo, props map[string]string, isInitialConnection bool) (driver.Conn, error)
+	ForceConnect(hostInfo HostInfo, props map[string]string, isInitialConnection bool) (driver.Conn, error)
 	Execute(name string, methodFunc ExecuteFunc, methodArgs ...any) (
 		wrappedReturnValue any,
 		wrappedReturnValue2 any,

--- a/driver_infrastructure/random_host_selector.go
+++ b/driver_infrastructure/random_host_selector.go
@@ -20,7 +20,7 @@ import "math/rand"
 
 type RandomHostSelector struct{}
 
-func (r *RandomHostSelector) GetHost(hosts []HostInfo, role HostRole, props map[string]any) (HostInfo, error) {
+func (r *RandomHostSelector) GetHost(hosts []HostInfo, role HostRole, props map[string]string) (HostInfo, error) {
 	eligibleHosts := FilterSlice(hosts, func(hostInfo HostInfo) bool {
 		return role == hostInfo.Role && hostInfo.Availability == AVAILABLE
 	})

--- a/driver_infrastructure/target_driver_dialect.go
+++ b/driver_infrastructure/target_driver_dialect.go
@@ -16,4 +16,6 @@
 
 package driver_infrastructure
 
-type TargetDriverDialect interface{}
+type TargetDriverDialect interface {
+	GetDsnFromProperties(properties map[string]string) string
+}

--- a/driver_infrastructure/utils.go
+++ b/driver_infrastructure/utils.go
@@ -21,16 +21,6 @@ import (
 	"database/sql/driver"
 )
 
-func DsnFromProperties(properties map[string]any) string {
-	// TODO
-	return ""
-}
-
-func PropertiesFromDsn(dsn string) map[string]any {
-	// TODO
-	return map[string]any{}
-}
-
 // Directly executes query on conn, and returns the first row.
 // Returns nil if unable to obtain a row.
 func GetFirstRowFromQuery(conn driver.Conn, query string) []driver.Value {
@@ -82,15 +72,6 @@ func FilterSlice[T any](slice []T, filter func(T) bool) []T {
 		if filter(v) {
 			result = append(result, v)
 		}
-	}
-	return result
-}
-
-func GetVerifiedWrapperPropertyValue[T any](props map[string]any, property AwsWrapperProperty) T {
-	propValue := property.Get(props)
-	result, ok := propValue.(T)
-	if !ok {
-		panic(GetMessage("AwsWrapperProperty.unexpectedType", property.Name, propValue))
 	}
 	return result
 }

--- a/plugin_helpers/plugin_manager.go
+++ b/plugin_helpers/plugin_manager.go
@@ -86,7 +86,7 @@ type PluginManagerImpl struct {
 	connProviderManager   driver_infrastructure.ConnectionProviderManager
 	defaultConnProvider   *driver_infrastructure.ConnectionProvider
 	effectiveConnProvider *driver_infrastructure.ConnectionProvider
-	props                 map[string]any
+	props                 map[string]string
 	pluginFuncMap         map[string]PluginChain
 	plugins               []*driver_infrastructure.ConnectionPlugin
 }
@@ -95,7 +95,7 @@ func NewPluginManagerImpl(
 	targetDriver driver.Driver,
 	defaultConnProvider *driver_infrastructure.ConnectionProvider,
 	effectiveConnProvider *driver_infrastructure.ConnectionProvider,
-	props map[string]any) *PluginManagerImpl {
+	props map[string]string) *PluginManagerImpl {
 	pluginFuncMap := make(map[string]PluginChain)
 	return &PluginManagerImpl{
 		targetDriver:          targetDriver,
@@ -108,7 +108,7 @@ func NewPluginManagerImpl(
 
 func (pluginManager *PluginManagerImpl) Init(
 	pluginService *driver_infrastructure.PluginService,
-	props map[string]any,
+	props map[string]string,
 	plugins []*driver_infrastructure.ConnectionPlugin) error {
 	pluginManager.pluginService = pluginService
 	pluginManager.plugins = plugins
@@ -117,7 +117,7 @@ func (pluginManager *PluginManagerImpl) Init(
 
 func (pluginManager *PluginManagerImpl) InitHostProvider(
 	initialUrl string,
-	props map[string]any,
+	props map[string]string,
 	hostListProviderService driver_infrastructure.HostListProviderService) error {
 	pluginFunc := func(plugin driver_infrastructure.ConnectionPlugin, targetFunc func() (any, any, bool, error)) (any, any, bool, error) {
 		initFunc := func() error {
@@ -143,7 +143,7 @@ func (pluginManager *PluginManagerImpl) InitHostProvider(
 
 func (pluginManager *PluginManagerImpl) Connect(
 	hostInfo driver_infrastructure.HostInfo,
-	props map[string]any,
+	props map[string]string,
 	isInitialConnection bool) (driver.Conn, error) {
 	pluginFunc := func(plugin driver_infrastructure.ConnectionPlugin, targetFunc func() (any, error)) (any, error) {
 		return plugin.Connect(hostInfo, props, isInitialConnection, targetFunc)
@@ -161,7 +161,7 @@ func (pluginManager *PluginManagerImpl) Connect(
 
 func (pluginManager *PluginManagerImpl) ForceConnect(
 	hostInfo driver_infrastructure.HostInfo,
-	props map[string]any,
+	props map[string]string,
 	isInitialConnection bool) (driver.Conn, error) {
 	pluginFunc := func(plugin driver_infrastructure.ConnectionPlugin, targetFunc func() (any, error)) (any, error) {
 		return plugin.ForceConnect(hostInfo, props, isInitialConnection, targetFunc)

--- a/plugin_helpers/plugin_service.go
+++ b/plugin_helpers/plugin_service.go
@@ -25,7 +25,7 @@ import (
 type PluginServiceImpl struct {
 	// TODO: dialect should be initialized using DialectManager's GetDialect.
 	pluginManager             *driver_infrastructure.PluginManager
-	props                     map[string]any
+	props                     map[string]string
 	currentConnection         driver.Conn
 	hostListProvider          driver_infrastructure.HostListProvider
 	currentHostInfo           driver_infrastructure.HostInfo
@@ -41,7 +41,7 @@ type PluginServiceImpl struct {
 	isInTransaction           bool
 }
 
-func NewPluginServiceImpl(pluginManager *driver_infrastructure.PluginManager, props map[string]any) *PluginServiceImpl {
+func NewPluginServiceImpl(pluginManager *driver_infrastructure.PluginManager, props map[string]string) *PluginServiceImpl {
 	return &PluginServiceImpl{pluginManager: pluginManager, props: props}
 }
 
@@ -127,7 +127,7 @@ func (p *PluginServiceImpl) UpdateHostAvailability(hosts []driver_infrastructure
 	panic("implement me")
 }
 
-func (p *PluginServiceImpl) Connect(hostInfo driver_infrastructure.HostInfo, props map[string]any) (driver.Conn, error) {
+func (p *PluginServiceImpl) Connect(hostInfo driver_infrastructure.HostInfo, props map[string]string) (driver.Conn, error) {
 	isInitialConnection := true
 	if p.currentConnection != nil {
 		isInitialConnection = false
@@ -135,7 +135,7 @@ func (p *PluginServiceImpl) Connect(hostInfo driver_infrastructure.HostInfo, pro
 	return (*p.pluginManager).Connect(hostInfo, props, isInitialConnection)
 }
 
-func (p *PluginServiceImpl) ForceConnect(hostInfo driver_infrastructure.HostInfo, props map[string]any) (driver.Conn, error) {
+func (p *PluginServiceImpl) ForceConnect(hostInfo driver_infrastructure.HostInfo, props map[string]string) (driver.Conn, error) {
 	isInitialConnection := true
 	if p.currentConnection != nil {
 		isInitialConnection = false
@@ -168,6 +168,6 @@ func (p *PluginServiceImpl) GetConnectionProvider() driver_infrastructure.Connec
 	panic("implement me")
 }
 
-func (p *PluginServiceImpl) GetProperties() map[string]any {
+func (p *PluginServiceImpl) GetProperties() map[string]string {
 	return p.props
 }

--- a/plugins/default_plugin.go
+++ b/plugins/default_plugin.go
@@ -29,7 +29,7 @@ type DefaultPlugin struct {
 
 func (d *DefaultPlugin) InitHostProvider(
 	initialUrl string,
-	props map[string]any,
+	props map[string]string,
 	hostListProviderService driver_infrastructure.HostListProviderService,
 	initHostProviderFunc func() error) error {
 	// Do nothing.
@@ -47,28 +47,28 @@ func (d *DefaultPlugin) Execute(methodName string, executeFunc driver_infrastruc
 
 func (d *DefaultPlugin) Connect(
 	hostInfo driver_infrastructure.HostInfo,
-	properties map[string]any,
+	props map[string]string,
 	isInitialConnection bool,
 	connectFunc driver_infrastructure.ConnectFunc) (driver.Conn, error) {
 	// It's guaranteed that this plugin is always the last in plugin chain so connectFunc can be ignored.
-	connProvider := d.ConnProviderManager.GetConnectionProvider(hostInfo, properties)
-	return d.connectInternal(hostInfo, properties, connProvider)
+	connProvider := d.ConnProviderManager.GetConnectionProvider(hostInfo, props)
+	return d.connectInternal(hostInfo, props, connProvider)
 }
 
 func (d *DefaultPlugin) ForceConnect(
 	hostInfo driver_infrastructure.HostInfo,
-	properties map[string]any,
+	props map[string]string,
 	isInitialConnection bool,
 	forceConnectFunc driver_infrastructure.ConnectFunc) (driver.Conn, error) {
 	// It's guaranteed that this plugin is always the last in plugin chain so connectFunc can be ignored.
-	return d.connectInternal(hostInfo, properties, d.DefaultConnProvider)
+	return d.connectInternal(hostInfo, props, d.DefaultConnProvider)
 }
 
 func (d *DefaultPlugin) connectInternal(
 	hostInfo driver_infrastructure.HostInfo,
-	properties map[string]any,
+	props map[string]string,
 	connProvider *driver_infrastructure.ConnectionProvider) (driver.Conn, error) {
-	conn, err := (*connProvider).Connect(hostInfo, properties)
+	conn, err := (*connProvider).Connect(hostInfo, props, d.PluginService)
 	(*d.PluginService).SetAvailability(hostInfo.AllAliases, driver_infrastructure.AVAILABLE)
 	return conn, err
 }

--- a/resources/en.json
+++ b/resources/en.json
@@ -1,5 +1,6 @@
 {
 	"AwsWrapperConn.underlyingConnDoesNotImplementRequiredInterface": "The underlying driver connection does not implement the required interface '%v'.",
+	"AwsWrapperProperty.invalidPropertyType": "Invalid wrapper property type: '%v'.",
 	"AwsWrapperProperty.unexpectedType": "Value of property '%v' was not the expected type. Received: '%v'.",
 	"AwsWrapperRows.underlyingRowsDoNotImplementRequiredInterface": "The underlying rows do not implement the required interface '%v'.",
 	"AwsWrapperStmt.underlyingStmtDoesNotImplementRequiredInterface": "The underlying driver statement does not implement the required interface '%v'.",

--- a/test/connection_plugin_chain_builder_test.go
+++ b/test/connection_plugin_chain_builder_test.go
@@ -27,7 +27,7 @@ package test
 //// TODO: complete once additional plugins have been added.
 //func TestSortPlugins(t *testing.T) {
 //	builder := &container.ConnectionPluginChainBuilder{}
-//	props := map[string]any{}
+//	props := map[string]string{}
 //	props[driver_infrastructure.PLUGINS.Name] = "iam,efm,failover"
 //	pluginManagerImpl := plugin_helpers.PluginManagerImpl{}
 //	pluginManager := driver_infrastructure.PluginManager(&pluginManagerImpl)
@@ -63,7 +63,7 @@ package test
 //
 //func TestPreservePluginOrder(t *testing.T) {
 //	builder := &container.ConnectionPluginChainBuilder{}
-//	props := map[string]any{}
+//	props := map[string]string{}
 //	props[driver_infrastructure.PLUGINS.Name] = "iam,efm,failover"
 //	props[driver_infrastructure.AUTO_SORT_PLUGIN_ORDER.Name] = false
 //	pluginManagerImpl := plugin_helpers.PluginManagerImpl{}
@@ -100,7 +100,7 @@ package test
 //
 //func TestSortPluginsWithStickToPrior(t *testing.T) {
 //	builder := &container.ConnectionPluginChainBuilder{}
-//	props := map[string]any{}
+//	props := map[string]string{}
 //	props[driver_infrastructure.PLUGINS.Name] = "dev,iam,executionTime,connectTime,efm,failover"
 //	pluginManagerImpl := plugin_helpers.PluginManagerImpl{}
 //	pluginManager := driver_infrastructure.PluginManager(&pluginManagerImpl)

--- a/test/driver_test.go
+++ b/test/driver_test.go
@@ -179,11 +179,11 @@ func TestIsDialectMySQL(t *testing.T) {
 }
 
 func TestWrapperUtilsQueryWithPluginsMySQL(t *testing.T) {
-	mockPluginManager := driver_infrastructure.PluginManager(plugin_helpers.NewPluginManagerImpl(nil, nil, nil, map[string]any{}))
+	mockPluginManager := driver_infrastructure.PluginManager(plugin_helpers.NewPluginManagerImpl(nil, nil, nil, map[string]string{}))
 	plugins := []*driver_infrastructure.ConnectionPlugin{
 		CreateTestPlugin(nil, 1, nil, nil, false),
 	}
-	_ = mockPluginManager.Init(nil, map[string]any{}, plugins)
+	_ = mockPluginManager.Init(nil, map[string]string{}, plugins)
 	mockContainer := container.Container{PluginManager: &mockPluginManager}
 	baseAwsWrapperConn := *awsDriver.NewAwsWrapperConn(MockDriverConn{}, mockContainer, awsDriver.MYSQL)
 	res, err := baseAwsWrapperConn.QueryContext(context.Background(), "", nil)
@@ -219,11 +219,11 @@ func TestWrapperUtilsQueryWithPluginsMySQL(t *testing.T) {
 }
 
 func TestWrapperUtilsQueryWithPluginsPg(t *testing.T) {
-	mockPluginManager := driver_infrastructure.PluginManager(plugin_helpers.NewPluginManagerImpl(nil, nil, nil, map[string]any{}))
+	mockPluginManager := driver_infrastructure.PluginManager(plugin_helpers.NewPluginManagerImpl(nil, nil, nil, map[string]string{}))
 	plugins := []*driver_infrastructure.ConnectionPlugin{
 		CreateTestPlugin(nil, 1, nil, nil, false),
 	}
-	_ = mockPluginManager.Init(nil, map[string]any{}, plugins)
+	_ = mockPluginManager.Init(nil, map[string]string{}, plugins)
 	mockContainer := container.Container{PluginManager: &mockPluginManager}
 
 	baseAwsWrapperConn := *awsDriver.NewAwsWrapperConn(MockDriverConn{}, mockContainer, awsDriver.PG)
@@ -260,11 +260,11 @@ func TestWrapperUtilsQueryWithPluginsPg(t *testing.T) {
 }
 
 func TestWrapperUtilsExecWithPlugins(t *testing.T) {
-	mockPluginManager := driver_infrastructure.PluginManager(plugin_helpers.NewPluginManagerImpl(nil, nil, nil, map[string]any{}))
+	mockPluginManager := driver_infrastructure.PluginManager(plugin_helpers.NewPluginManagerImpl(nil, nil, nil, map[string]string{}))
 	plugins := []*driver_infrastructure.ConnectionPlugin{
 		CreateTestPlugin(nil, 1, nil, nil, false),
 	}
-	_ = mockPluginManager.Init(nil, map[string]any{}, plugins)
+	_ = mockPluginManager.Init(nil, map[string]string{}, plugins)
 	mockContainer := container.Container{PluginManager: &mockPluginManager}
 
 	mockUnderlyingConn := MockConn{nil, MockResult{}, nil, nil, false}
@@ -287,11 +287,11 @@ func TestWrapperUtilsExecWithPlugins(t *testing.T) {
 }
 
 func TestWrapperUtilsBeginWithPlugins(t *testing.T) {
-	mockPluginManager := driver_infrastructure.PluginManager(plugin_helpers.NewPluginManagerImpl(nil, nil, nil, map[string]any{}))
+	mockPluginManager := driver_infrastructure.PluginManager(plugin_helpers.NewPluginManagerImpl(nil, nil, nil, map[string]string{}))
 	plugins := []*driver_infrastructure.ConnectionPlugin{
 		CreateTestPlugin(nil, 1, nil, nil, false),
 	}
-	_ = mockPluginManager.Init(nil, map[string]any{}, plugins)
+	_ = mockPluginManager.Init(nil, map[string]string{}, plugins)
 	mockContainer := container.Container{PluginManager: &mockPluginManager}
 
 	mockUnderlyingConn := MockConn{nil, nil, MockTx{}, nil, false}
@@ -314,11 +314,11 @@ func TestWrapperUtilsBeginWithPlugins(t *testing.T) {
 }
 
 func TestWrapperUtilsPrepareWithPlugins(t *testing.T) {
-	mockPluginManager := driver_infrastructure.PluginManager(plugin_helpers.NewPluginManagerImpl(nil, nil, nil, map[string]any{}))
+	mockPluginManager := driver_infrastructure.PluginManager(plugin_helpers.NewPluginManagerImpl(nil, nil, nil, map[string]string{}))
 	plugins := []*driver_infrastructure.ConnectionPlugin{
 		CreateTestPlugin(nil, 1, nil, nil, false),
 	}
-	_ = mockPluginManager.Init(nil, map[string]any{}, plugins)
+	_ = mockPluginManager.Init(nil, map[string]string{}, plugins)
 	mockContainer := container.Container{PluginManager: &mockPluginManager}
 
 	mockUnderlyingConn := MockConn{nil, nil, nil, MockStmt{}, false}

--- a/test/plugin_manager_test.go
+++ b/test/plugin_manager_test.go
@@ -66,7 +66,7 @@ func (t TestPlugin) Execute(methodName string, executeFunc driver_infrastructure
 
 func (t TestPlugin) Connect(
 	hostInfo driver_infrastructure.HostInfo,
-	properties map[string]any,
+	props map[string]string,
 	isInitialConnection bool,
 	connectFunc driver_infrastructure.ConnectFunc) (driver.Conn, error) {
 	*t.calls = append(*t.calls, fmt.Sprintf("%s%v:before connect", reflect.TypeOf(t), t.id))
@@ -91,7 +91,7 @@ func (t TestPlugin) Connect(
 
 func (t TestPlugin) ForceConnect(
 	hostInfo driver_infrastructure.HostInfo,
-	properties map[string]any,
+	props map[string]string,
 	isInitialConnection bool,
 	connectFunc driver_infrastructure.ConnectFunc) (driver.Conn, error) {
 	*t.calls = append(*t.calls, fmt.Sprintf("%s%v:before forceConnect", reflect.TypeOf(t), t.id))
@@ -132,7 +132,7 @@ func (t TestPlugin) NotifyHostListChanged(changes map[string]map[driver_infrastr
 
 func (t TestPlugin) InitHostProvider(
 	initialUrl string,
-	props map[string]any,
+	props map[string]string,
 	hostListProviderService driver_infrastructure.HostListProviderService,
 	initHostProviderFunc func() error) error {
 	// Do nothing
@@ -174,8 +174,9 @@ func CreateTestPlugin(calls *[]string, id int, connection driver.Conn, err error
 
 func TestExecuteFunctionCallA(t *testing.T) {
 	mockTargetDriver := &MockTargetDriver{}
-	props := make(map[string]any)
-	defaultConnProvider := driver_infrastructure.ConnectionProvider(driver_infrastructure.NewDriverConnectionProvider(mockTargetDriver))
+	props := make(map[string]string)
+	driverConnProvider := driver_infrastructure.NewDriverConnectionProvider(mockTargetDriver)
+	defaultConnProvider := driver_infrastructure.ConnectionProvider(driverConnProvider)
 	target := plugin_helpers.NewPluginManagerImpl(mockTargetDriver, &defaultConnProvider, nil, props)
 	pluginServiceImpl := driver_infrastructure.PluginService(&plugin_helpers.PluginServiceImpl{})
 	var calls []string
@@ -215,7 +216,7 @@ func TestExecuteFunctionCallA(t *testing.T) {
 
 func TestExecuteFunctionCallB(t *testing.T) {
 	mockTargetDriver := &MockTargetDriver{}
-	props := make(map[string]any)
+	props := make(map[string]string)
 	defaultConnProvider := driver_infrastructure.ConnectionProvider(driver_infrastructure.NewDriverConnectionProvider(mockTargetDriver))
 	target := plugin_helpers.NewPluginManagerImpl(mockTargetDriver, &defaultConnProvider, nil, props)
 	pluginServiceImpl := driver_infrastructure.PluginService(&plugin_helpers.PluginServiceImpl{})
@@ -254,7 +255,7 @@ func TestExecuteFunctionCallB(t *testing.T) {
 
 func TestExecuteFunctionCallC(t *testing.T) {
 	mockTargetDriver := &MockTargetDriver{}
-	props := make(map[string]any)
+	props := make(map[string]string)
 	defaultConnProvider := driver_infrastructure.ConnectionProvider(driver_infrastructure.NewDriverConnectionProvider(mockTargetDriver))
 	target := plugin_helpers.NewPluginManagerImpl(mockTargetDriver, &defaultConnProvider, nil, props)
 	pluginServiceImpl := driver_infrastructure.PluginService(&plugin_helpers.PluginServiceImpl{})
@@ -291,7 +292,7 @@ func TestExecuteFunctionCallC(t *testing.T) {
 
 func TestConnect(t *testing.T) {
 	mockTargetDriver := &MockTargetDriver{}
-	props := make(map[string]any)
+	props := make(map[string]string)
 	defaultConnProvider := driver_infrastructure.ConnectionProvider(driver_infrastructure.NewDriverConnectionProvider(mockTargetDriver))
 	target := plugin_helpers.NewPluginManagerImpl(mockTargetDriver, &defaultConnProvider, nil, props)
 	pluginServiceImpl := driver_infrastructure.PluginService(&plugin_helpers.PluginServiceImpl{})
@@ -322,7 +323,7 @@ func TestConnect(t *testing.T) {
 
 func TestForceConnect(t *testing.T) {
 	mockTargetDriver := &MockTargetDriver{}
-	props := make(map[string]any)
+	props := make(map[string]string)
 	defaultConnProvider := driver_infrastructure.ConnectionProvider(driver_infrastructure.NewDriverConnectionProvider(mockTargetDriver))
 	target := plugin_helpers.NewPluginManagerImpl(mockTargetDriver, &defaultConnProvider, nil, props)
 	pluginServiceImpl := driver_infrastructure.PluginService(&plugin_helpers.PluginServiceImpl{})
@@ -354,7 +355,7 @@ func TestForceConnect(t *testing.T) {
 func TestConnectWithErrorBefore(t *testing.T) {
 	expectedError := errors.New("test error")
 	mockTargetDriver := &MockTargetDriver{}
-	props := make(map[string]any)
+	props := make(map[string]string)
 	defaultConnProvider := driver_infrastructure.ConnectionProvider(driver_infrastructure.NewDriverConnectionProvider(mockTargetDriver))
 	target := plugin_helpers.NewPluginManagerImpl(mockTargetDriver, &defaultConnProvider, nil, props)
 	pluginServiceImpl := driver_infrastructure.PluginService(&plugin_helpers.PluginServiceImpl{})
@@ -387,7 +388,7 @@ func TestConnectWithErrorBefore(t *testing.T) {
 func TestConnectWithErrorAfter(t *testing.T) {
 	expectedError := errors.New("test error")
 	mockTargetDriver := &MockTargetDriver{}
-	props := make(map[string]any)
+	props := make(map[string]string)
 	defaultConnProvider := driver_infrastructure.ConnectionProvider(driver_infrastructure.NewDriverConnectionProvider(mockTargetDriver))
 	target := plugin_helpers.NewPluginManagerImpl(mockTargetDriver, &defaultConnProvider, nil, props)
 	pluginServiceImpl := driver_infrastructure.PluginService(&plugin_helpers.PluginServiceImpl{})
@@ -429,7 +430,7 @@ func TestTwoConnectionsDoNotBlockOneAnother(t *testing.T) {
 	waitForReleaseDbResourceToProceed.Add(1)
 
 	mockTargetDriver := &MockTargetDriver{}
-	props := make(map[string]any)
+	props := make(map[string]string)
 	defaultConnProvider := driver_infrastructure.ConnectionProvider(driver_infrastructure.NewDriverConnectionProvider(mockTargetDriver))
 	pluginServiceImpl := driver_infrastructure.PluginService(&plugin_helpers.PluginServiceImpl{})
 

--- a/test/random_host_selector_test.go
+++ b/test/random_host_selector_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestGetHostGivenUnavailableHost(t *testing.T) {
 	for i := 0; i < 50; i++ {
-		props := map[string]any{}
+		props := map[string]string{}
 
 		unavailableHost := driver_infrastructure.HostInfo{Host: "someUnavailableHost", Role: driver_infrastructure.READER, Availability: driver_infrastructure.UNAVAILABLE}
 		availableHost := driver_infrastructure.HostInfo{Host: "someAvailableHost", Role: driver_infrastructure.READER, Availability: driver_infrastructure.AVAILABLE}
@@ -44,7 +44,7 @@ func TestGetHostGivenUnavailableHost(t *testing.T) {
 
 func TestGetHostGivenMultipleUnavailableHosts(t *testing.T) {
 	for i := 0; i < 50; i++ {
-		props := map[string]any{}
+		props := map[string]string{}
 
 		hosts := []driver_infrastructure.HostInfo{
 			{Host: "someUnavailableHost", Role: driver_infrastructure.READER, Availability: driver_infrastructure.UNAVAILABLE},


### PR DESCRIPTION
### Summary

Change properties type to map[string][string]

### Description

Properties retrieved from parsing provided dsns is of the type map[string][string], which is incompatible with the type map[string][any], which is used throughout the wrapper. This PR changes the properties type to be map[string][string] everywhere, and adds the type checking/conversion in the GetVerifiedWrapperPropertyValue function.

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
