### PR TITLE
fix: error when parsing MySQL dsn without additional parameters

### DIFF
--- a/test/dsn_parser_test.go
+++ b/test/dsn_parser_test.go
@@ -57,6 +57,22 @@ func TestParseDsnPgxUrl(t *testing.T) {
 	assert.Equal(t, "bar", props["foo"])
 }
 
+func TestParseDsnPgxUrlWithoutParams(t *testing.T) {
+	dsn := "postgres://someUser:somePassword@localhost:5432/pgx_test"
+	props, err := utils.ParseDsn(dsn)
+
+	if err != nil {
+		t.Errorf(`Unexpected error when calling ParseDsn: %s, Error: %q`, dsn, err)
+	}
+
+	assert.Equal(t, "postgresql", props[utils.DRIVER_PROTOCOL])
+	assert.Equal(t, "someUser", props[utils.USER])
+	assert.Equal(t, "somePassword", props[utils.PASSWORD])
+	assert.Equal(t, "localhost", props[utils.HOST])
+	assert.Equal(t, "5432", props[utils.PORT])
+	assert.Equal(t, "pgx_test", props[utils.DATABASE])
+}
+
 func TestParseDsnPgxKeyValue(t *testing.T) {
 	dsn := "user=someUser password=somePassword host=localhost port=5432 database=pgx_test sslmode=disable foo=bar"
 	props, err := utils.ParseDsn(dsn)
@@ -91,4 +107,20 @@ func TestParseDsnMySql(t *testing.T) {
 	assert.Equal(t, "myDatabase", props[utils.DATABASE])
 	assert.Equal(t, "bar", props["foo"])
 	assert.Equal(t, "snap", props["pop"])
+}
+
+func TestParseDsnMySqlWithoutParams(t *testing.T) {
+	dsn := "someUser:somePassword@tcp(mydatabase.com:3306)/myDatabase"
+	props, err := utils.ParseDsn(dsn)
+
+	if err != nil {
+		t.Errorf(`Unexpected error when calling ParseDsn: %s, Error: %q`, dsn, err)
+	}
+
+	assert.Equal(t, "mysql", props[utils.DRIVER_PROTOCOL])
+	assert.Equal(t, "someUser", props[utils.USER])
+	assert.Equal(t, "somePassword", props[utils.PASSWORD])
+	assert.Equal(t, "mydatabase.com", props[utils.HOST])
+	assert.Equal(t, "3306", props[utils.PORT])
+	assert.Equal(t, "myDatabase", props[utils.DATABASE])
 }

--- a/utils/dsn_parser.go
+++ b/utils/dsn_parser.go
@@ -369,7 +369,7 @@ func parseMySqlDsn(dsn string) (properties map[string]string, err error) {
 
 	// dbname[?param1=value1&...&paramN=valueN]
 	queryIndex := strings.Index(dsn[lastSlashIndex:], "?") + lastSlashIndex
-	if queryIndex == -1 {
+	if queryIndex <= lastSlashIndex {
 		properties[DATABASE], err = url.PathUnescape(dsn[lastSlashIndex+1:])
 	} else {
 		properties[DATABASE], err = url.PathUnescape(dsn[lastSlashIndex+1 : queryIndex])


### PR DESCRIPTION
### Summary

Fix error when parsing mysql dsn without additional parameters

### Description

Parsing a MySQL dsn without additional parameters (ex. `someUser:somePassword@tcp(mydatabase.com:3306)/myDatabase`),  results in an error: `panic: runtime error: slice bounds out of range`. This PR adds a check to ensure the range used when fetching the database from the dsn is valid.

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
