### PR TITLE
fix: update dialect

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -19,7 +19,6 @@ package container
 import (
 	"awssql/driver_infrastructure"
 	"awssql/plugin_helpers"
-	"awssql/plugins/efm"
 	"awssql/utils"
 )
 
@@ -80,11 +79,4 @@ func NewContainer(dsn string) (Container, error) {
 		PluginService: pluginService,
 		Props:         props,
 	}, nil
-}
-
-// This cleans up all long standing caches. To be called at the end of program not each time a Conn is closed.
-func ClearAllCaches() {
-	if efm.EFM_MONITORS != nil {
-		efm.EFM_MONITORS.Clear()
-	}
 }

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -20,6 +20,8 @@ import (
 	"awssql/container"
 	"awssql/driver_infrastructure"
 	"awssql/error_util"
+	"awssql/plugin_helpers"
+	"awssql/plugins/efm"
 	"context"
 	"database/sql"
 	"database/sql/driver"
@@ -77,6 +79,13 @@ func init() {
 	sql.Register(
 		"awssql",
 		&AwsWrapperDriver{})
+}
+
+// This cleans up all long standing caches. To be called at the end of program, not each time a Conn is closed.
+func ClearCaches() {
+	driver_infrastructure.ClearCaches()
+	plugin_helpers.ClearCaches()
+	efm.ClearCaches()
 }
 
 type AwsWrapperConn struct {

--- a/driver_infrastructure/plugin_helpers.go
+++ b/driver_infrastructure/plugin_helpers.go
@@ -21,10 +21,10 @@ import (
 	"database/sql/driver"
 )
 
-type ConnectFunc func() (any, error)
+type ConnectFunc func() (driver.Conn, error)
 type ExecuteFunc func() (any, any, bool, error)
 type PluginExecFunc func(plugin ConnectionPlugin, targetFunc func() (any, any, bool, error)) (any, any, bool, error)
-type PluginConnectFunc func(plugin ConnectionPlugin, targetFunc func() (any, error)) (any, error)
+type PluginConnectFunc func(plugin ConnectionPlugin, targetFunc func() (driver.Conn, error)) (driver.Conn, error)
 
 type HostListProviderService interface {
 	IsStaticHostListProvider() bool
@@ -86,4 +86,20 @@ type PluginManager interface {
 
 type CanReleaseResources interface {
 	ReleaseResources()
+}
+
+// This cleans up all long standing caches. To be called at the end of program, not each time a Conn is closed.
+func ClearCaches() {
+	if knownEndpointDialectsCache != nil {
+		knownEndpointDialectsCache.Clear()
+	}
+	if primaryClusterIdCache != nil {
+		primaryClusterIdCache.Clear()
+	}
+	if suggestedPrimaryClusterCache != nil {
+		suggestedPrimaryClusterCache.Clear()
+	}
+	if TopologyCache != nil {
+		TopologyCache.Clear()
+	}
 }

--- a/plugins/base_connection_plugin.go
+++ b/plugins/base_connection_plugin.go
@@ -43,12 +43,7 @@ func (b BaseConnectionPlugin) Connect(
 	props map[string]string,
 	isInitialConnection bool,
 	connectFunc driver_infrastructure.ConnectFunc) (driver.Conn, error) {
-	result, err := connectFunc()
-	conn, ok := result.(driver.Conn)
-	if ok {
-		return conn, err
-	}
-	return nil, err
+	return connectFunc()
 }
 
 func (b BaseConnectionPlugin) ForceConnect(
@@ -56,12 +51,7 @@ func (b BaseConnectionPlugin) ForceConnect(
 	props map[string]string,
 	isInitialConnection bool,
 	connectFunc driver_infrastructure.ConnectFunc) (driver.Conn, error) {
-	result, err := connectFunc()
-	conn, ok := result.(driver.Conn)
-	if ok {
-		return conn, err
-	}
-	return nil, err
+	return connectFunc()
 }
 
 func (b BaseConnectionPlugin) AcceptsStrategy(role host_info_util.HostRole, strategy string) bool {

--- a/plugins/efm/host_monitoring_plugin.go
+++ b/plugins/efm/host_monitoring_plugin.go
@@ -63,16 +63,15 @@ func (b *HostMonitorConnectionPlugin) Connect(
 	props map[string]string,
 	isInitialConnection bool,
 	connectFunc driver_infrastructure.ConnectFunc) (driver.Conn, error) {
-	result, err := connectFunc()
-	conn, ok := result.(driver.Conn)
-	if ok {
-		if utils.IdentifyRdsUrlType(hostInfo.Host).IsRds {
-			hostInfo.ResetAliases()
-			b.pluginService.FillAliases(conn, hostInfo)
-		}
-		return conn, err
+	conn, err := connectFunc()
+	if err != nil {
+		return nil, err
 	}
-	return nil, err
+	if utils.IdentifyRdsUrlType(hostInfo.Host).IsRds {
+		hostInfo.ResetAliases()
+		b.pluginService.FillAliases(conn, hostInfo)
+	}
+	return conn, err
 }
 
 func (b *HostMonitorConnectionPlugin) NotifyConnectionChanged(changes map[driver_infrastructure.HostChangeOptions]bool) driver_infrastructure.OldConnectionSuggestedAction {

--- a/plugins/efm/monitor_service.go
+++ b/plugins/efm/monitor_service.go
@@ -58,6 +58,12 @@ func NewMonitorServiceImpl(pluginService driver_infrastructure.PluginService) *M
 	return &MonitorServiceImpl{pluginService: pluginService}
 }
 
+func ClearCaches() {
+	if EFM_MONITORS != nil {
+		EFM_MONITORS.Clear()
+	}
+}
+
 func (m *MonitorServiceImpl) StartMonitoring(conn driver.Conn, hostInfo *host_info_util.HostInfo, props map[string]string,
 	failureDetectionTimeMillis int, failureDetectionIntervalMillis int, failureDetectionCount int) (*MonitorConnectionContext, error) {
 	if conn == nil {

--- a/plugins/iam/iam_auth_plugin.go
+++ b/plugins/iam/iam_auth_plugin.go
@@ -112,12 +112,9 @@ func (iamAuthPlugin *IamAuthPlugin) connectInternal(
 		}
 	}
 
-	result, err := connectFunc()
+	conn, err := connectFunc()
 	if err == nil {
-		conn, ok := result.(driver.Conn)
-		if ok {
-			return conn, err
-		}
+		return conn, nil
 	} else {
 		slog.Debug(error_util.GetMessage("IamAuthPlugin.connectionError", err))
 		if !iamAuthPlugin.pluginService.IsLoginError(err) || !isCachedToken {
@@ -132,12 +129,7 @@ func (iamAuthPlugin *IamAuthPlugin) connectInternal(
 		return nil, err
 	}
 
-	result2, err := connectFunc()
-	conn, ok := result2.(driver.Conn)
-	if ok {
-		return conn, err
-	}
-	return nil, err
+	return connectFunc()
 }
 
 func (iamAuthPlugin *IamAuthPlugin) fetchAndSetToken(

--- a/resources/en.json
+++ b/resources/en.json
@@ -62,6 +62,7 @@
 	"PluginManagerImpl.releaseResources": "Releasing resources from PluginManagerImpl.",
 	"PluginServiceImpl.releaseResources": "Releasing resources from PluginServiceImpl.",
 	"PluginServiceImpl.nilHost": "Current host evaluates to nil.",
+	"PluginServiceImpl.initialHostNotSet": "Unable to update dialect, initial HostInfo has not been set.",
 	"PluginServiceImpl.nilConn": "Unable to set current connection, given connection evaluates to nil.",
 	"PluginServiceImpl.setCurrentHost": "Set current host to '%v'.",
 	"PluginServiceImpl.hostListEmpty": "Host list is empty.",

--- a/test/efm_test.go
+++ b/test/efm_test.go
@@ -17,13 +17,13 @@
 package test
 
 import (
-	"awssql/container"
 	"awssql/driver_infrastructure"
 	"awssql/host_info_util"
 	"awssql/plugin_helpers"
 	"awssql/plugins/efm"
 	"awssql/property_util"
 	"awssql/utils"
+	"database/sql/driver"
 	"fmt"
 	"strings"
 	"testing"
@@ -168,7 +168,7 @@ func mockHostMonitoringPlugin(props map[string]string) (*efm.HostMonitorConnecti
 	monitoringPlugin, _ := plugin.(*efm.HostMonitorConnectionPlugin)
 
 	// Reset caches and query counter.
-	container.ClearAllCaches()
+	efm.ClearCaches()
 	queryCounter = 0
 	return monitoringPlugin, err
 }
@@ -185,7 +185,7 @@ func TestHostMonitoringPluginConnect(t *testing.T) {
 	assert.Nil(t, err)
 	rdsHostInfo, err := host_info_util.NewHostInfoBuilder().SetHost("instance-a-1.xyz.us-east-2.rds.amazonaws.com").Build()
 	assert.Nil(t, err)
-	connectFunc := func() (any, error) {
+	connectFunc := func() (driver.Conn, error) {
 		return &MockDriverConnection{}, nil
 	}
 
@@ -276,7 +276,7 @@ func TestHostMonitoringPluginExecuteThrowsError(t *testing.T) {
 	pluginService := &plugin_helpers.PluginServiceImpl{}
 	plugin, _ := factory.GetInstance(pluginService, map[string]string{"a": "1"})
 	// Reset caches and query counter.
-	container.ClearAllCaches()
+	efm.ClearCaches()
 	queryCounter = 0
 
 	assert.Zero(t, efm.EFM_MONITORS.Size())

--- a/test/iam_auth_plugin_test.go
+++ b/test/iam_auth_plugin_test.go
@@ -24,11 +24,11 @@ import (
 	"awssql/plugins/iam"
 	"awssql/property_util"
 	"awssql/region_util"
+	"database/sql/driver"
 	"testing"
 	"time"
 
 	"github.com/go-sql-driver/mysql"
-
 	"github.com/stretchr/testify/assert"
 )
 
@@ -45,7 +45,7 @@ func beforeIamAuthPluginTests(props map[string]string) (driver_infrastructure.Pl
 func TestIamAuthPluginConnect(t *testing.T) {
 	hostInfo, err := host_info_util.NewHostInfoBuilder().SetHost("database-test-name.cluster-XYZ.us-east-2.rds.amazonaws.com").SetPort(1234).Build()
 	assert.Nil(t, err)
-	mockConnFunc := func() (any, error) { return &MockConn{nil, nil, nil, nil, true}, nil }
+	mockConnFunc := func() (driver.Conn, error) { return &MockConn{nil, nil, nil, nil, true}, nil }
 
 	props := map[string]string{
 		property_util.USER.Name:            "someUser",
@@ -70,7 +70,7 @@ func TestIamAuthPluginConnect(t *testing.T) {
 func TestIamAuthPluginConnectWithIamProps(t *testing.T) {
 	hostInfo, err := host_info_util.NewHostInfoBuilder().SetHost("database-test-name.cluster-XYZ.us-east-2.rds.amazonaws.com").SetPort(1234).Build()
 	assert.Nil(t, err)
-	mockConnFunc := func() (any, error) { return &MockConn{nil, nil, nil, nil, true}, nil }
+	mockConnFunc := func() (driver.Conn, error) { return &MockConn{nil, nil, nil, nil, true}, nil }
 
 	props := map[string]string{
 		property_util.USER.Name:             "someUser",
@@ -98,7 +98,7 @@ func TestIamAuthPluginConnectWithIamProps(t *testing.T) {
 func TestIamAuthPluginConnectInvalidRegionError(t *testing.T) {
 	hostInfo, err := host_info_util.NewHostInfoBuilder().SetHost("mydatabasewithnoregion.com").SetPort(1234).Build()
 	assert.Nil(t, err)
-	mockConnFunc := func() (any, error) { return &MockConn{nil, nil, nil, nil, true}, nil }
+	mockConnFunc := func() (driver.Conn, error) { return &MockConn{nil, nil, nil, nil, true}, nil }
 
 	props := map[string]string{
 		property_util.USER.Name:            "someUser",
@@ -118,7 +118,7 @@ func TestIamAuthPluginConnectInvalidRegionError(t *testing.T) {
 func TestIamAuthPluginConnectPopulatesEmptyTokenCache(t *testing.T) {
 	hostInfo, err := host_info_util.NewHostInfoBuilder().SetHost("database-test-name.cluster-XYZ.us-east-2.rds.amazonaws.com").SetPort(1234).Build()
 	assert.Nil(t, err)
-	mockConnFunc := func() (any, error) { return &MockConn{nil, nil, nil, nil, true}, nil }
+	mockConnFunc := func() (driver.Conn, error) { return &MockConn{nil, nil, nil, nil, true}, nil }
 
 	props := map[string]string{
 		property_util.USER.Name:            "someUser",
@@ -139,7 +139,7 @@ func TestIamAuthPluginConnectPopulatesEmptyTokenCache(t *testing.T) {
 func TestIamAuthPluginConnectUsesCachedToken(t *testing.T) {
 	hostInfo, err := host_info_util.NewHostInfoBuilder().SetHost("database-test-name.cluster-XYZ.us-east-2.rds.amazonaws.com").SetPort(1234).Build()
 	assert.Nil(t, err)
-	mockConnFunc := func() (any, error) { return &MockConn{nil, nil, nil, nil, true}, nil }
+	mockConnFunc := func() (driver.Conn, error) { return &MockConn{nil, nil, nil, nil, true}, nil }
 
 	props := map[string]string{
 		property_util.USER.Name:             "someUser",
@@ -173,7 +173,7 @@ func TestIamAuthPluginConnectUsesCachedToken(t *testing.T) {
 func TestIamAuthPluginConnectCacheExpiredToken(t *testing.T) {
 	hostInfo, err := host_info_util.NewHostInfoBuilder().SetHost("database-test-name.cluster-XYZ.us-east-2.rds.amazonaws.com").SetPort(1234).Build()
 	assert.Nil(t, err)
-	mockConnFunc := func() (any, error) { return &MockConn{nil, nil, nil, nil, true}, nil }
+	mockConnFunc := func() (driver.Conn, error) { return &MockConn{nil, nil, nil, nil, true}, nil }
 
 	props := map[string]string{
 		property_util.USER.Name:             "someUser",
@@ -216,7 +216,7 @@ func TestIamAuthPluginConnectTtlExpiredCachedToken(t *testing.T) {
 	assert.Nil(t, err)
 	mockLoginError := &mysql.MySQLError{SQLState: [5]byte(([]byte(driver_infrastructure.SqlStateAccessError))[:5])}
 	mockConnFuncCallCounter := 0
-	mockConnFunc := func() (any, error) {
+	mockConnFunc := func() (driver.Conn, error) {
 		if mockConnFuncCallCounter == 0 {
 			mockConnFuncCallCounter++
 			return nil, mockLoginError
@@ -266,7 +266,7 @@ func TestIamAuthPluginConnectLoginError(t *testing.T) {
 	hostInfo, err := host_info_util.NewHostInfoBuilder().SetHost("database-test-name.cluster-XYZ.us-east-2.rds.amazonaws.com").SetPort(1234).Build()
 	assert.Nil(t, err)
 	mockLoginError := &mysql.MySQLError{SQLState: [5]byte(([]byte(driver_infrastructure.SqlStateAccessError))[:5])}
-	mockConnFunc := func() (any, error) { return nil, mockLoginError }
+	mockConnFunc := func() (driver.Conn, error) { return nil, mockLoginError }
 
 	props := map[string]string{
 		property_util.USER.Name:            "someUser",

--- a/test/mock_implementations.go
+++ b/test/mock_implementations.go
@@ -77,16 +77,12 @@ func (t TestPlugin) Connect(
 		*t.calls = append(*t.calls, fmt.Sprintf("%s%v:connection", reflect.TypeOf(t), t.id))
 		return t.connection, nil
 	}
-	result, err := connectFunc()
+	conn, err := connectFunc()
 	if !t.isBefore && t.error != nil {
 		return nil, t.error
 	}
 	*t.calls = append(*t.calls, fmt.Sprintf("%s%v:after connect", reflect.TypeOf(t), t.id))
-	conn, ok := result.(driver.Conn)
-	if ok {
-		return conn, err
-	}
-	return nil, err
+	return conn, err
 }
 
 func (t TestPlugin) ForceConnect(
@@ -99,13 +95,9 @@ func (t TestPlugin) ForceConnect(
 		*t.calls = append(*t.calls, fmt.Sprintf("%s%v:forced connection", reflect.TypeOf(t), t.id))
 		return t.connection, nil
 	}
-	result, err := connectFunc()
+	conn, err := connectFunc()
 	*t.calls = append(*t.calls, fmt.Sprintf("%s%v:after forceConnect", reflect.TypeOf(t), t.id))
-	conn, ok := result.(driver.Conn)
-	if ok {
-		return conn, err
-	}
-	return nil, err
+	return conn, err
 }
 
 func (t TestPlugin) AcceptsStrategy(role host_info_util.HostRole, strategy string) bool {


### PR DESCRIPTION
### Summary

Fixes call to UpdateDialect. 

### Description

- includes a call to `UpdateDialect` when connecting with the default plugin 
- refactors the connect pipeline to function without casts 
- initializes `knownEndpointDialectsCache` as shared across dialect managers
- corrects host values passed to `GetDialectForUpdate`
- includes aurora cluster endpoints in `knownEndpointDialectsCache`
- cleans up log messages for dialects and releaseResources 
- removes unnecessary comments for linter and session state

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
