### PR TITLE
fix: use rds_host_list_provider if failover is disabled

### DIFF
--- a/driver_infrastructure/mysql_database_dialects.go
+++ b/driver_infrastructure/mysql_database_dialects.go
@@ -110,14 +110,14 @@ func (m *AuroraMySQLDatabaseDialect) GetHostListProvider(
 	initialDsn string,
 	hostListProviderService HostListProviderService,
 	pluginService PluginService) HostListProvider {
-	pluginsProp := props[property_util.PLUGINS.Name]
+	pluginsProp := property_util.GetVerifiedWrapperPropertyValue[string](props, property_util.PLUGINS)
 
-	if strings.Contains(pluginsProp, "failover") || pluginsProp == "" {
-		slog.Debug("Failover is enabled. Getting MonitoringRdsHostListProvider")
+	if strings.Contains(pluginsProp, "failover") {
+		slog.Debug("Failover is enabled. Using MonitoringRdsHostListProvider")
 		return HostListProvider(NewMonitoringRdsHostListProvider(hostListProviderService, m, props, initialDsn, pluginService))
 	}
 
-	slog.Debug("Failover NOT enabled. Getting RdsHostListProvider")
+	slog.Debug("Failover NOT enabled. Using RdsHostListProvider")
 	return HostListProvider(NewRdsHostListProvider(hostListProviderService, m, props, initialDsn, nil, nil))
 }
 

--- a/driver_infrastructure/pg_database_dialects.go
+++ b/driver_infrastructure/pg_database_dialects.go
@@ -106,14 +106,14 @@ func (m *AuroraPgDatabaseDialect) GetHostListProvider(
 	initialDsn string,
 	hostListProviderService HostListProviderService,
 	pluginService PluginService) HostListProvider {
-	pluginsProp := props[property_util.PLUGINS.Name]
+	pluginsProp := property_util.GetVerifiedWrapperPropertyValue[string](props, property_util.PLUGINS)
 
-	if strings.Contains(pluginsProp, "failover") || pluginsProp == "" {
-		slog.Debug("Failover is enabled. Getting MonitoringRdsHostListProvider")
+	if strings.Contains(pluginsProp, "failover") {
+		slog.Debug("Failover is enabled. Using MonitoringRdsHostListProvider")
 		return HostListProvider(NewMonitoringRdsHostListProvider(hostListProviderService, m, props, initialDsn, pluginService))
 	}
 
-	slog.Debug("Failover NOT enabled. Getting RdsHostListProvider")
+	slog.Debug("Failover NOT enabled. Using RdsHostListProvider")
 	return HostListProvider(NewRdsHostListProvider(hostListProviderService, m, props, initialDsn, nil, nil))
 }
 


### PR DESCRIPTION
### Summary

fix: use rds_host_list_provider if failover is disabled

### Description

If we aren't using failover, we should use rds_host_list_provider instead so we don't use failover-specific logic

### Additional Reviewers


### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
