### PR TITLE
fix: remove unnecessary idpName property

### DIFF
--- a/plugins/federated_auth/adfs_credentials_provider_factory.go
+++ b/plugins/federated_auth/adfs_credentials_provider_factory.go
@@ -76,7 +76,7 @@ func (a *AdfsCredentialsProviderFactory) GetUriAndParamsFromSignInPage(uri strin
 	}
 
 	client := a.httpClientProvider(
-		property_util.GetVerifiedWrapperPropertyValue[int](props, property_util.HTTP_TIMEOUT),
+		property_util.GetVerifiedWrapperPropertyValue[int](props, property_util.HTTP_TIMEOUT_MS),
 		property_util.GetVerifiedWrapperPropertyValue[bool](props, property_util.SSL_INSECURE),
 		nil)
 
@@ -148,7 +148,7 @@ func (a *AdfsCredentialsProviderFactory) getSamlAssertionFromPost(uri string, pa
 		return "", err
 	}
 	client := a.httpClientProvider(
-		property_util.GetVerifiedWrapperPropertyValue[int](props, property_util.HTTP_TIMEOUT),
+		property_util.GetVerifiedWrapperPropertyValue[int](props, property_util.HTTP_TIMEOUT_MS),
 		property_util.GetVerifiedWrapperPropertyValue[bool](props, property_util.SSL_INSECURE),
 		jar)
 

--- a/plugins/federated_auth/okta_credentials_provider_factory.go
+++ b/plugins/federated_auth/okta_credentials_provider_factory.go
@@ -57,7 +57,7 @@ func (o *OktaCredentialsProviderFactory) GetSamlAssertion(props map[string]strin
 		return "", err
 	}
 
-	httpTimeoutMs := property_util.GetVerifiedWrapperPropertyValue[int](props, property_util.HTTP_TIMEOUT)
+	httpTimeoutMs := property_util.GetVerifiedWrapperPropertyValue[int](props, property_util.HTTP_TIMEOUT_MS)
 	insecureSsl := property_util.GetVerifiedWrapperPropertyValue[bool](props, property_util.SSL_INSECURE)
 	client := o.httpClientProvider(httpTimeoutMs, insecureSsl, nil)
 
@@ -110,7 +110,7 @@ func (o *OktaCredentialsProviderFactory) GetSessionToken(props map[string]string
 	idpHost := property_util.GetVerifiedWrapperPropertyValue[string](props, property_util.IDP_ENDPOINT)
 	idpUser := property_util.GetVerifiedWrapperPropertyValue[string](props, property_util.IDP_USERNAME)
 	idpPassword := property_util.GetVerifiedWrapperPropertyValue[string](props, property_util.IDP_PASSWORD)
-	httpTimeoutMs := property_util.GetVerifiedWrapperPropertyValue[int](props, property_util.HTTP_TIMEOUT)
+	httpTimeoutMs := property_util.GetVerifiedWrapperPropertyValue[int](props, property_util.HTTP_TIMEOUT_MS)
 	insecureSsl := property_util.GetVerifiedWrapperPropertyValue[bool](props, property_util.SSL_INSECURE)
 
 	client := o.httpClientProvider(httpTimeoutMs, insecureSsl, nil)

--- a/property_util/aws_wrapper_property.go
+++ b/property_util/aws_wrapper_property.go
@@ -119,7 +119,6 @@ var ALL_WRAPPER_PROPERTIES = map[string]bool{
 	CLUSTER_TOPOLOGY_HIGH_REFRESH_RATE_MS.Name:  true,
 	WEIGHTED_RANDOM_HOST_WEIGHT_PAIRS.Name:      true,
 	IAM_TOKEN_EXPIRATION.Name:                   true,
-	IDP_NAME.Name:                               true,
 	IDP_USERNAME.Name:                           true,
 	IDP_PASSWORD.Name:                           true,
 	IDP_PORT.Name:                               true,
@@ -129,7 +128,7 @@ var ALL_WRAPPER_PROPERTIES = map[string]bool{
 	RELAYING_PARTY_ID.Name:                      true,
 	DB_USER.Name:                                true,
 	APP_ID.Name:                                 true,
-	HTTP_TIMEOUT.Name:                           true,
+	HTTP_TIMEOUT_MS.Name:                        true,
 	SSL_INSECURE.Name:                           true,
 }
 
@@ -372,13 +371,6 @@ var IAM_TOKEN_EXPIRATION = AwsWrapperProperty{
 	wrapperPropertyType: WRAPPER_TYPE_INT,
 }
 
-var IDP_NAME = AwsWrapperProperty{
-	Name:                "idpName",
-	description:         "The name of the Identity Provider implementation used.",
-	defaultValue:        "adfs",
-	wrapperPropertyType: WRAPPER_TYPE_STRING,
-}
-
 var IDP_USERNAME = AwsWrapperProperty{
 	Name:                "idpUsername",
 	description:         "The federated user name.",
@@ -442,7 +434,7 @@ var APP_ID = AwsWrapperProperty{
 	wrapperPropertyType: WRAPPER_TYPE_STRING,
 }
 
-var HTTP_TIMEOUT = AwsWrapperProperty{
+var HTTP_TIMEOUT_MS = AwsWrapperProperty{
 	Name:                "httpTimeoutMs",
 	description:         "The timeout value in milliseconds provided to http clients.",
 	defaultValue:        "60000",

--- a/resources/en.json
+++ b/resources/en.json
@@ -32,7 +32,6 @@
 	"Conn.doesNotImplementRequiredInterface": "The given connection does not implement the required interface '%v'.",
 	"Conn.invalidTransactionIsolationLevel": "An invalid transaction isolation level was provided: '%v'.",
 	"ConnectionProvider.unsupportedHostSelectorStrategy": "Unsupported host selection strategy '%v' specified for this connection provider '%v'. Please visit the documentation for all supported strategies.",
-	"CredentialsProviderFactory.unsupportedIdp": "Unsupported Identity Provider '%s'. Please visit to the documentation for supported Identity Providers.",
 	"DatabaseDialectManager.getDialectError": "Was not able to get a database dialect.",
 	"DatabaseDialectManager.invalidDriverProtocol": "Invalid driver protocol from properties: %v.",
 	"DefaultConnectionPlugin.noHostsAvailable": "The default connection plugin received an empty host list from the plugin service.",

--- a/test/federated_auth_plugin_test.go
+++ b/test/federated_auth_plugin_test.go
@@ -57,29 +57,6 @@ func setup(props map[string]string) *federated_auth.FederatedAuthPlugin {
 	return federated_auth.NewFederatedAuthPlugin(mockPluginService, credentialsProviderFactory, mockIamTokenUtility)
 }
 
-func TestGetFederatedAuthPlugin(t *testing.T) {
-	props := map[string]string{
-		property_util.IDP_NAME.Name: "adfs",
-	}
-	pluginFactory := federated_auth.NewFederatedAuthPluginFactory()
-	_, err := pluginFactory.GetInstance(&MockPluginServiceImpl{}, props)
-	assert.Nil(t, err)
-
-	props = map[string]string{
-		property_util.IDP_NAME.Name: "",
-	}
-	pluginFactory = federated_auth.NewFederatedAuthPluginFactory()
-	_, err = pluginFactory.GetInstance(&MockPluginServiceImpl{}, props)
-	assert.Nil(t, err)
-
-	props = map[string]string{
-		property_util.IDP_NAME.Name: "any",
-	}
-	pluginFactory = federated_auth.NewFederatedAuthPluginFactory()
-	_, err = pluginFactory.GetInstance(&MockPluginServiceImpl{}, props)
-	assert.Equal(t, error_util.NewIllegalArgumentError(error_util.GetMessage("CredentialsProviderFactory.unsupportedIdp", "any")), err)
-}
-
 func TestCachedToken(t *testing.T) {
 	props := map[string]string{
 		property_util.DRIVER_PROTOCOL.Name: "postgresql",


### PR DESCRIPTION
### Summary

<!--- General summary / title -->

### Description

- remove unnecessary idpName wrapper property
- rename HTTP_TIMEOUT wrapper property to HTTP_TIMEOUT_MS
- simplify federated auth plugin variable isCachedToken creation

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
