### PR TITLE
fix: retry connection until connected to writer

### DIFF
--- a/driver_infrastructure/pgx_error_handler.go
+++ b/driver_infrastructure/pgx_error_handler.go
@@ -18,9 +18,10 @@ package driver_infrastructure
 
 import (
 	"errors"
-	"github.com/jackc/pgx/v5/pgconn"
 	"slices"
 	"strings"
+
+	"github.com/jackc/pgx/v5/pgconn"
 )
 
 var AccessErrors = []string{
@@ -49,7 +50,7 @@ func (p *PgxErrorHandler) IsNetworkError(err error) bool {
 		return true
 	}
 
-	if strings.Contains(err.Error(), "unexpected EOF") {
+	if strings.Contains(err.Error(), "unexpected EOF") || strings.Contains(err.Error(), "broken pipe") {
 		return true
 	}
 

--- a/test_framework/container/tests/basic_connectivity_test.go
+++ b/test_framework/container/tests/basic_connectivity_test.go
@@ -17,36 +17,13 @@
 package test
 
 import (
-	awsDriver "awssql/driver"
 	"awssql/test_framework/container/test_utils"
 	"database/sql"
-	"fmt"
-	"log/slog"
 	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
-
-func basicSetup(name string) (*test_utils.AuroraTestUtility, error) {
-	slog.Info(fmt.Sprintf("Test started: %s.", name))
-	env, err := test_utils.GetCurrentTestEnvironment()
-	if err != nil {
-		return nil, err
-	}
-	auroraTestUtility := test_utils.NewAuroraTestUtility(env.Info().Region)
-	test_utils.EnableAllConnectivity()
-	err = test_utils.VerifyClusterStatus()
-	if err != nil {
-		return nil, err
-	}
-	return auroraTestUtility, nil
-}
-
-func basicCleanup(name string) {
-	awsDriver.ClearCaches()
-	slog.Info(fmt.Sprintf("Test finished: %s.", name))
-}
 
 func TestBasicConnectivityWrapper(t *testing.T) {
 	defer test_utils.BasicCleanupAfterBasicSetup(t)


### PR DESCRIPTION
### Summary

Potential fixes for the failover integration tests.

### Description

The current tests for failing over in a transaction require creating and dropping connections. This is only possible through connection to the writer instance. It is possible that the previous failover may result in connecting to a stale writer instance. This PR introduces a retry mechanism when connecting with a cluster endpoint to ensure we are connected to the writer before executing such queries. 

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
