### PR TITLE
fix: is connection closed

### DIFF
--- a/driver_infrastructure/cluster_topology_monitor.go
+++ b/driver_infrastructure/cluster_topology_monitor.go
@@ -336,7 +336,7 @@ func (c *ClusterTopologyMonitorImpl) delay(useHighRefreshRate bool) {
 }
 
 func (c *ClusterTopologyMonitorImpl) closeConnection(conn driver.Conn) {
-	if conn != nil && !utils.IsConnectionLost(conn) {
+	if conn != nil && !c.pluginService.GetTargetDriverDialect().IsClosed(conn) {
 		_ = conn.Close()
 	}
 }

--- a/driver_infrastructure/driver_dialect.go
+++ b/driver_infrastructure/driver_dialect.go
@@ -27,6 +27,7 @@ type DriverDialect interface {
 	PrepareDsn(properties map[string]string, info *host_info_util.HostInfo) string
 	IsNetworkError(err error) bool
 	IsLoginError(err error) bool
+	IsClosed(conn driver.Conn) bool
 	IsDriverRegistered(drivers map[string]driver.Driver) bool
 	RegisterDriver()
 }

--- a/driver_infrastructure/mysql_driver_dialect.go
+++ b/driver_infrastructure/mysql_driver_dialect.go
@@ -61,6 +61,15 @@ func (m MySQLDriverDialect) IsLoginError(err error) bool {
 	return m.errorHandler.IsLoginError(err)
 }
 
+func (m MySQLDriverDialect) IsClosed(conn driver.Conn) bool {
+	validator, ok := conn.(driver.Validator)
+	if ok {
+		return !validator.IsValid()
+	}
+	// This should not be reached.
+	return false
+}
+
 func (m MySQLDriverDialect) IsDriverRegistered(drivers map[string]driver.Driver) bool {
 	_, exists := drivers[MYSQL_DRIVER_REGISTRATION_NAME]
 	return exists

--- a/driver_infrastructure/pgx_driver_dialect.go
+++ b/driver_infrastructure/pgx_driver_dialect.go
@@ -70,6 +70,15 @@ func (p PgxDriverDialect) IsLoginError(err error) bool {
 	return p.errorHandler.IsLoginError(err)
 }
 
+func (p PgxDriverDialect) IsClosed(conn driver.Conn) bool {
+	stdLibConn, ok := conn.(*stdlib.Conn)
+	if ok {
+		return stdLibConn.Conn().IsClosed()
+	}
+	// This should not be reached.
+	return false
+}
+
 func (p PgxDriverDialect) IsDriverRegistered(drivers map[string]driver.Driver) bool {
 	_, existsV4 := drivers[PGX_DRIVER_REGISTRATION_NAME]
 	_, existsV5 := drivers[PGX_V5_DRIVER_REGISTRATION_NAME]

--- a/plugin_helpers/plugin_service.go
+++ b/plugin_helpers/plugin_service.go
@@ -160,7 +160,7 @@ func (p *PluginServiceImpl) SetCurrentConnection(
 			_, connectionObjectHasChanged := changes[driver_infrastructure.CONNECTION_OBJECT_CHANGED]
 			_, preserve := pluginOpinions[driver_infrastructure.PRESERVE]
 
-			shouldCloseConnection := connectionObjectHasChanged && !utils.IsConnectionLost(oldConnection) && !preserve
+			shouldCloseConnection := connectionObjectHasChanged && !p.GetTargetDriverDialect().IsClosed(oldConnection) && !preserve
 			if shouldCloseConnection {
 				oldConnection.Close()
 			}

--- a/plugins/efm/host_monitoring_plugin.go
+++ b/plugins/efm/host_monitoring_plugin.go
@@ -97,6 +97,7 @@ func (b *HostMonitorConnectionPlugin) Execute(
 
 	failureDetectionTimeMillis := property_util.GetVerifiedWrapperPropertyValue[int](b.props, property_util.FAILURE_DETECTION_TIME_MS)
 	failureDetectionIntervalMillis := property_util.GetVerifiedWrapperPropertyValue[int](b.props, property_util.FAILURE_DETECTION_INTERVAL_MS)
+	failureDetectionProbeTimeoutMillis := property_util.GetVerifiedWrapperPropertyValue[int](b.props, property_util.FAILURE_DETECTION_PROBE_TIMEOUT_MS)
 	failureDetectionCount := property_util.GetVerifiedWrapperPropertyValue[int](b.props, property_util.FAILURE_DETECTION_COUNT)
 
 	b.initMonitorService()
@@ -109,7 +110,7 @@ func (b *HostMonitorConnectionPlugin) Execute(
 		slog.Debug(error_util.GetMessage("HostMonitoringConnectionPlugin.activatedMonitoring", methodName))
 		monitorState, err = b.monitorService.StartMonitoring(
 			b.pluginService.GetCurrentConnectionRef(), monitoringHostInfo, b.props,
-			failureDetectionTimeMillis, failureDetectionIntervalMillis, failureDetectionCount)
+			failureDetectionTimeMillis, failureDetectionIntervalMillis, failureDetectionProbeTimeoutMillis, failureDetectionCount)
 		if err != nil {
 			slog.Warn(err.Error())
 			wrappedErr = err

--- a/plugins/efm/monitor.go
+++ b/plugins/efm/monitor.go
@@ -42,7 +42,7 @@ type Monitor interface {
 }
 
 func NewMonitorImpl(pluginService driver_infrastructure.PluginService, hostInfo *host_info_util.HostInfo, props map[string]string,
-	failureDetectionTimeMillis int, failureDetectionIntervalMillis int, failureDetectionCount int) *MonitorImpl {
+	failureDetectionTimeMillis int, failureDetectionIntervalMillis int, failureDetectionProbeTimeoutMillis int, failureDetectionCount int) *MonitorImpl {
 	monitoringConnectionProps := props
 	for propKey, propValue := range props {
 		if strings.HasPrefix(propKey, property_util.MONITORING_PROPERTY_PREFIX) {
@@ -51,13 +51,14 @@ func NewMonitorImpl(pluginService driver_infrastructure.PluginService, hostInfo 
 		}
 	}
 	monitor := &MonitorImpl{
-		hostInfo:                      hostInfo,
-		monitoringProps:               monitoringConnectionProps,
-		pluginService:                 pluginService,
-		failureDetectionTimeNanos:     time.Millisecond * time.Duration(failureDetectionTimeMillis),
-		failureDetectionIntervalNanos: time.Millisecond * time.Duration(failureDetectionIntervalMillis),
-		failureDetectionCount:         failureDetectionCount,
-		NewStates:                     map[time.Time][]weak.Pointer[MonitorConnectionState]{},
+		hostInfo:                          hostInfo,
+		monitoringProps:                   monitoringConnectionProps,
+		pluginService:                     pluginService,
+		failureDetectionTimeNanos:         time.Millisecond * time.Duration(failureDetectionTimeMillis),
+		failureDetectionIntervalNanos:     time.Millisecond * time.Duration(failureDetectionIntervalMillis),
+		failureDetectionProbeTimeoutNanos: time.Millisecond * time.Duration(failureDetectionProbeTimeoutMillis),
+		failureDetectionCount:             failureDetectionCount,
+		NewStates:                         map[time.Time][]weak.Pointer[MonitorConnectionState]{},
 	}
 
 	monitor.wg.Add(2)
@@ -68,21 +69,22 @@ func NewMonitorImpl(pluginService driver_infrastructure.PluginService, hostInfo 
 }
 
 type MonitorImpl struct {
-	hostInfo                      *host_info_util.HostInfo
-	MonitoringConn                driver.Conn
-	pluginService                 driver_infrastructure.PluginService
-	monitoringProps               map[string]string
-	failureDetectionTimeNanos     time.Duration
-	failureDetectionIntervalNanos time.Duration
-	FailureCount                  int
-	failureDetectionCount         int
-	InvalidHostStartTime          time.Time
-	ActiveStates                  []weak.Pointer[MonitorConnectionState]
-	NewStates                     map[time.Time][]weak.Pointer[MonitorConnectionState]
-	Stopped                       bool
-	HostUnhealthy                 bool
-	lock                          sync.RWMutex
-	wg                            sync.WaitGroup
+	hostInfo                          *host_info_util.HostInfo
+	MonitoringConn                    driver.Conn
+	pluginService                     driver_infrastructure.PluginService
+	monitoringProps                   map[string]string
+	failureDetectionTimeNanos         time.Duration
+	failureDetectionIntervalNanos     time.Duration
+	failureDetectionProbeTimeoutNanos time.Duration
+	FailureCount                      int
+	failureDetectionCount             int
+	InvalidHostStartTime              time.Time
+	ActiveStates                      []weak.Pointer[MonitorConnectionState]
+	NewStates                         map[time.Time][]weak.Pointer[MonitorConnectionState]
+	Stopped                           bool
+	HostUnhealthy                     bool
+	lock                              sync.RWMutex
+	wg                                sync.WaitGroup
 }
 
 func (m *MonitorImpl) CanDispose() bool {
@@ -237,7 +239,7 @@ func (m *MonitorImpl) CheckConnectionStatus() bool {
 		m.pluginService.SetTelemetryContext(parentCtx)
 	}()
 
-	if m.MonitoringConn == nil || utils.IsConnectionLost(m.MonitoringConn) {
+	if m.MonitoringConn == nil || m.pluginService.GetTargetDriverDialect().IsClosed(m.MonitoringConn) {
 		// Open a new connection.
 		slog.Debug(error_util.GetMessage("MonitorImpl.openingMonitoringConnection", m.hostInfo.Host))
 		newMonitoringConn, err := m.pluginService.ForceConnect(m.hostInfo, m.monitoringProps)
@@ -249,18 +251,9 @@ func (m *MonitorImpl) CheckConnectionStatus() bool {
 		return true
 	}
 
-	// If implemented, validate by driver.Validator. Currently, only mysql Conns support this.
-	validator, implementsIsValid := m.MonitoringConn.(driver.Validator)
-	if implementsIsValid {
-		return validator.IsValid()
-	}
-	// As a last resort, check connection by executing a query.
-	queryer, implementsQueryer := m.MonitoringConn.(driver.QueryerContext)
-	if implementsQueryer {
-		_, err := queryer.QueryContext(context.TODO(), "select 1", []driver.NamedValue{})
-		return err == nil
-	}
-	return false
+	ctx, cancel := context.WithTimeout(context.Background(), m.failureDetectionProbeTimeoutNanos)
+	defer cancel()
+	return utils.IsReachable(m.MonitoringConn, ctx)
 }
 
 func (m *MonitorImpl) isStopped() bool {

--- a/plugins/efm/monitor_service.go
+++ b/plugins/efm/monitor_service.go
@@ -34,7 +34,7 @@ var EFM_MONITORS *utils.SlidingExpirationCache[Monitor]
 
 type MonitorService interface {
 	StartMonitoring(conn *driver.Conn, hostInfo *host_info_util.HostInfo, props map[string]string,
-		failureDetectionTimeMillis int, failureDetectionIntervalMillis int, failureDetectionCount int) (*MonitorConnectionState, error)
+		failureDetectionTimeMillis int, failureDetectionIntervalMillis int, failureDetectionProbeTimeoutMillis int, failureDetectionCount int) (*MonitorConnectionState, error)
 	StopMonitoring(state *MonitorConnectionState, connToAbort driver.Conn)
 }
 
@@ -65,14 +65,14 @@ func ClearCaches() {
 }
 
 func (m *MonitorServiceImpl) StartMonitoring(conn *driver.Conn, hostInfo *host_info_util.HostInfo, props map[string]string,
-	failureDetectionTimeMillis int, failureDetectionIntervalMillis int, failureDetectionCount int) (*MonitorConnectionState, error) {
+	failureDetectionTimeMillis int, failureDetectionIntervalMillis int, failureDetectionProbeTimeoutMillis int, failureDetectionCount int) (*MonitorConnectionState, error) {
 	if conn == nil {
 		return nil, error_util.NewGenericAwsWrapperError(error_util.GetMessage("MonitorServiceImpl.illegalArgumentError", "conn"))
 	}
 	if hostInfo.IsNil() {
 		return nil, error_util.NewGenericAwsWrapperError(error_util.GetMessage("MonitorServiceImpl.illegalArgumentError", "hostInfo"))
 	}
-	monitor := m.getMonitor(hostInfo, props, failureDetectionTimeMillis, failureDetectionIntervalMillis, failureDetectionCount)
+	monitor := m.getMonitor(hostInfo, props, failureDetectionTimeMillis, failureDetectionIntervalMillis, failureDetectionProbeTimeoutMillis, failureDetectionCount)
 	state := NewMonitorConnectionState(conn)
 	monitor.StartMonitoring(state)
 	return state, nil
@@ -91,13 +91,14 @@ func (m *MonitorServiceImpl) StopMonitoring(state *MonitorConnectionState, connT
 }
 
 func (m *MonitorServiceImpl) getMonitor(hostInfo *host_info_util.HostInfo, props map[string]string, failureDetectionTimeMillis int,
-	failureDetectionIntervalMillis int, failureDetectionCount int) Monitor {
+	failureDetectionIntervalMillis int, failureDetectionProbeTimeoutMillis int, failureDetectionCount int) Monitor {
 	monitorKey := fmt.Sprintf("%d:%d:%d:%s", failureDetectionTimeMillis, failureDetectionIntervalMillis, failureDetectionCount, hostInfo.GetUrl())
 	cacheExpirationNano := time.Millisecond * time.Duration(property_util.GetVerifiedWrapperPropertyValue[int](props, property_util.MONITOR_DISPOSAL_TIME_MS))
 	return EFM_MONITORS.ComputeIfAbsent(
 		monitorKey,
 		func() Monitor {
-			return NewMonitorImpl(m.pluginService, hostInfo, props, failureDetectionTimeMillis, failureDetectionIntervalMillis, failureDetectionCount)
+			return NewMonitorImpl(m.pluginService, hostInfo, props, failureDetectionTimeMillis,
+				failureDetectionIntervalMillis, failureDetectionProbeTimeoutMillis, failureDetectionCount)
 		},
 		cacheExpirationNano)
 }

--- a/plugins/failover_plugin.go
+++ b/plugins/failover_plugin.go
@@ -581,7 +581,7 @@ func (p *FailoverPlugin) InvalidateCurrentConnection() {
 		utils.Rollback(conn, p.pluginService.GetCurrentTx())
 	}
 
-	if !utils.IsConnectionLost(conn) {
+	if !p.pluginService.GetTargetDriverDialect().IsClosed(conn) {
 		_ = conn.Close()
 	}
 }

--- a/property_util/aws_wrapper_property.go
+++ b/property_util/aws_wrapper_property.go
@@ -113,6 +113,7 @@ var ALL_WRAPPER_PROPERTIES = map[string]bool{
 	FAILURE_DETECTION_ENABLED.Name:               true,
 	FAILURE_DETECTION_TIME_MS.Name:               true,
 	FAILURE_DETECTION_INTERVAL_MS.Name:           true,
+	FAILURE_DETECTION_PROBE_TIMEOUT_MS.Name:      true,
 	FAILURE_DETECTION_COUNT.Name:                 true,
 	MONITOR_DISPOSAL_TIME_MS.Name:                true,
 	FAILOVER_TIMEOUT_MS.Name:                     true,
@@ -268,6 +269,13 @@ var FAILURE_DETECTION_INTERVAL_MS = AwsWrapperProperty{
 	Name:                "failureDetectionIntervalMs",
 	description:         "Interval in millis between probes to database host.",
 	defaultValue:        "5000",
+	wrapperPropertyType: WRAPPER_TYPE_INT,
+}
+
+var FAILURE_DETECTION_PROBE_TIMEOUT_MS = AwsWrapperProperty{
+	Name:                "failureDetectionProbeTimeoutMs",
+	description:         "Timeout in millis for the probe to check connection status. Connection check fails when times out.",
+	defaultValue:        "1000",
 	wrapperPropertyType: WRAPPER_TYPE_INT,
 }
 

--- a/test/aws_secrets_manager_connection_plugin_test.go
+++ b/test/aws_secrets_manager_connection_plugin_test.go
@@ -47,7 +47,7 @@ func beforeAwsSecretsManagerConnectionPluginTests(props map[string]string) drive
 func TestAwsSecretsManagerConnectionPluginConnect(t *testing.T) {
 	hostInfo, err := host_info_util.NewHostInfoBuilder().SetHost("database-test-name.cluster-XYZ.us-east-2.rds.amazonaws.com").SetPort(1234).Build()
 	assert.Nil(t, err)
-	mockConnFunc := func() (driver.Conn, error) { return &MockConn{nil, nil, nil, nil, true, 0, 0}, nil }
+	mockConnFunc := func() (driver.Conn, error) { return &MockConn{throwError: true}, nil }
 
 	props := map[string]string{
 		property_util.SECRETS_MANAGER_REGION.Name:    "us-west-2",
@@ -68,7 +68,7 @@ func TestAwsSecretsManagerConnectionPluginConnect(t *testing.T) {
 func TestAwsSecretsManagerConnectionPluginForceConnect(t *testing.T) {
 	hostInfo, err := host_info_util.NewHostInfoBuilder().SetHost("database-test-name.cluster-XYZ.us-east-2.rds.amazonaws.com").SetPort(1234).Build()
 	assert.Nil(t, err)
-	mockConnFunc := func() (driver.Conn, error) { return &MockConn{nil, nil, nil, nil, true, 0, 0}, nil }
+	mockConnFunc := func() (driver.Conn, error) { return &MockConn{throwError: true}, nil }
 
 	props := map[string]string{
 		property_util.SECRETS_MANAGER_REGION.Name:    "us-west-2",
@@ -89,7 +89,7 @@ func TestAwsSecretsManagerConnectionPluginForceConnect(t *testing.T) {
 func TestAwsSecretsManagerConnectionPluginProps(t *testing.T) {
 	hostInfo, err := host_info_util.NewHostInfoBuilder().SetHost("database-test-name.cluster-XYZ.us-east-2.rds.amazonaws.com").SetPort(1234).Build()
 	assert.Nil(t, err)
-	mockConnFunc := func() (driver.Conn, error) { return &MockConn{nil, nil, nil, nil, true, 0, 0}, nil }
+	mockConnFunc := func() (driver.Conn, error) { return &MockConn{throwError: true}, nil }
 
 	props := map[string]string{
 		property_util.SECRETS_MANAGER_REGION.Name:    "us-west-2",
@@ -126,7 +126,7 @@ func TestAwsSecretsManagerConnectionPluginInvalidRegion(t *testing.T) {
 func TestAwsSecretsManagerConnectionPluginValidRegionThroughArn(t *testing.T) {
 	hostInfo, err := host_info_util.NewHostInfoBuilder().SetHost("database-test-name.cluster-XYZ.us-east-2.rds.amazonaws.com").SetPort(1234).Build()
 	assert.Nil(t, err)
-	mockConnFunc := func() (driver.Conn, error) { return &MockConn{nil, nil, nil, nil, true, 0, 0}, nil }
+	mockConnFunc := func() (driver.Conn, error) { return &MockConn{throwError: true}, nil }
 
 	props := map[string]string{
 		property_util.SECRETS_MANAGER_SECRET_ID.Name: "arn:aws:secretsmanager:us-west-2:account-id:secret:default",
@@ -164,7 +164,7 @@ func TestAwsSecretsManagerConnectionPluginCacheSize1(t *testing.T) {
 
 	hostInfo, err := host_info_util.NewHostInfoBuilder().SetHost("database-test-name.cluster-XYZ.us-east-2.rds.amazonaws.com").SetPort(1234).Build()
 	assert.Nil(t, err)
-	mockConnFunc := func() (driver.Conn, error) { return &MockConn{nil, nil, nil, nil, true, 0, 0}, nil }
+	mockConnFunc := func() (driver.Conn, error) { return &MockConn{throwError: true}, nil }
 
 	props := map[string]string{
 		property_util.SECRETS_MANAGER_REGION.Name:    "us-west-2",
@@ -186,7 +186,7 @@ func TestAwsSecretsManagerConnectionPluginCacheSize1(t *testing.T) {
 func TestAwsSecretsManagerConnectionPluginUsingExpiredSecret(t *testing.T) {
 	hostInfo, err := host_info_util.NewHostInfoBuilder().SetHost("database-test-name.cluster-XYZ.us-east-2.rds.amazonaws.com").SetPort(1234).Build()
 	assert.Nil(t, err)
-	mockConnFunc := func() (driver.Conn, error) { return &MockConn{nil, nil, nil, nil, true, 0, 0}, nil }
+	mockConnFunc := func() (driver.Conn, error) { return &MockConn{throwError: true}, nil }
 	secretId := "myId"
 	region := "us-west-2"
 	cachedUsername := "cachedUsername"
@@ -220,7 +220,7 @@ func TestAwsSecretsManagerConnectionPluginUsingExpiredSecret(t *testing.T) {
 func TestAwsSecretsManagerConnectionPluginConnectingUsingCache(t *testing.T) {
 	hostInfo, err := host_info_util.NewHostInfoBuilder().SetHost("database-test-name.cluster-XYZ.us-east-2.rds.amazonaws.com").SetPort(1234).Build()
 	assert.Nil(t, err)
-	mockConnFunc := func() (driver.Conn, error) { return &MockConn{nil, nil, nil, nil, true, 0, 0}, nil }
+	mockConnFunc := func() (driver.Conn, error) { return &MockConn{throwError: true}, nil }
 	secretId := "myId"
 	region := "us-west-2"
 	cachedUsername := "cachedUsername"
@@ -254,7 +254,7 @@ func TestAwsSecretsManagerConnectionPluginConnectingUsingCache(t *testing.T) {
 func TestAwsSecretsManagerConnectionPluginMultipleConnectionsCache(t *testing.T) {
 	hostInfo, err := host_info_util.NewHostInfoBuilder().SetHost("database-test-name.cluster-XYZ.us-east-2.rds.amazonaws.com").SetPort(1234).Build()
 	assert.Nil(t, err)
-	mockConnFunc := func() (driver.Conn, error) { return &MockConn{nil, nil, nil, nil, true, 0, 0}, nil }
+	mockConnFunc := func() (driver.Conn, error) { return &MockConn{throwError: true}, nil }
 	secretIds := [4]string{"id1", "id1", "id3", "id4"}
 	region := [4]string{"us-west-2", "us-west-1", "us-west-2", "us-west-2"}
 

--- a/test/driver_test.go
+++ b/test/driver_test.go
@@ -85,7 +85,7 @@ func TestIsDialectPg(t *testing.T) {
 	if implementsQueryer {
 		t.Errorf("Should return false, connection does not implement QueryContext.")
 	}
-	testConnWithQuery := &MockConn{nil, nil, nil, nil, true, 0, 0}
+	testConnWithQuery := &MockConn{throwError: true}
 	passesQuery := pgDialect.IsDialect(testConnWithQuery)
 	if passesQuery {
 		t.Errorf("Should return false, QueryContext throws an error.")
@@ -136,7 +136,7 @@ func TestIsDialectPg(t *testing.T) {
 
 func TestIsDialectMySQL(t *testing.T) {
 	mySqlDialect := driver_infrastructure.MySQLDatabaseDialect{}
-	testConnWithQuery := &MockConn{nil, nil, nil, nil, true, 0, 0}
+	testConnWithQuery := &MockConn{throwError: true}
 
 	testConnWithQuery.updateQueryRow([]string{"variable_name"}, []driver.Value{"version_comment"})
 	returnsRow := mySqlDialect.IsDialect(testConnWithQuery)
@@ -220,7 +220,7 @@ func TestWrapperUtilsQueryWithPluginsMySQL(t *testing.T) {
 		t.Errorf("An AWS Wrapper Conn with an underlying connection that does not support QueryContext should not return a result.")
 	}
 
-	mockUnderlyingConn := &MockConn{nil, nil, nil, nil, false, 0, 0}
+	mockUnderlyingConn := &MockConn{}
 	mockUnderlyingConn.updateQueryRow([]string{"column"}, []driver.Value{"test"})
 	mockAwsWrapperConn := awsDriver.NewAwsWrapperConn(mockContainer, driver_infrastructure.MYSQL)
 	err = mockPluginService.SetCurrentConnection(mockUnderlyingConn, mockHostInfo, nil)
@@ -268,7 +268,7 @@ func TestWrapperUtilsQueryWithPluginsPg(t *testing.T) {
 		t.Errorf("An AWS Wrapper Conn with an underlying connection that does not support QueryContext should not return a result.")
 	}
 
-	mockUnderlyingConn := &MockConn{nil, nil, nil, nil, false, 0, 0}
+	mockUnderlyingConn := &MockConn{}
 	err = mockPluginService.SetCurrentConnection(mockUnderlyingConn, mockHostInfo, nil)
 	assert.Nil(t, err)
 
@@ -308,7 +308,7 @@ func TestWrapperUtilsExecWithPlugins(t *testing.T) {
 	_ = mockPluginManager.Init(nil, plugins)
 	mockContainer := container.Container{PluginManager: mockPluginManager, PluginService: mockPluginService}
 
-	mockUnderlyingConn := &MockConn{nil, MockResult{}, nil, nil, false, 0, 0}
+	mockUnderlyingConn := &MockConn{execResult: MockResult{}}
 	err := mockPluginService.SetCurrentConnection(mockUnderlyingConn, mockHostInfo, nil)
 	assert.Nil(t, err)
 	mockAwsWrapperConn := *awsDriver.NewAwsWrapperConn(mockContainer, driver_infrastructure.PG)
@@ -342,7 +342,7 @@ func TestWrapperUtilsBeginWithPlugins(t *testing.T) {
 	_ = mockPluginManager.Init(nil, plugins)
 	mockContainer := container.Container{PluginManager: mockPluginManager, PluginService: mockPluginService}
 
-	mockUnderlyingConn := &MockConn{nil, nil, MockTx{}, nil, false, 0, 0}
+	mockUnderlyingConn := &MockConn{beginResult: MockTx{}}
 	err := mockPluginService.SetCurrentConnection(mockUnderlyingConn, mockHostInfo, nil)
 	assert.Nil(t, err)
 	mockAwsWrapperConn := *awsDriver.NewAwsWrapperConn(mockContainer, driver_infrastructure.PG)
@@ -376,7 +376,7 @@ func TestWrapperUtilsPrepareWithPlugins(t *testing.T) {
 	_ = mockPluginManager.Init(nil, plugins)
 	mockContainer := container.Container{PluginManager: mockPluginManager, PluginService: mockPluginService}
 
-	mockUnderlyingConn := &MockConn{nil, nil, nil, MockStmt{}, false, 0, 0}
+	mockUnderlyingConn := &MockConn{prepareResult: MockStmt{}}
 	err := mockPluginService.SetCurrentConnection(mockUnderlyingConn, mockHostInfo, nil)
 	assert.Nil(t, err)
 	mockAwsWrapperConn := *awsDriver.NewAwsWrapperConn(mockContainer, driver_infrastructure.PG)

--- a/test/iam_auth_plugin_test.go
+++ b/test/iam_auth_plugin_test.go
@@ -40,7 +40,7 @@ func beforeIamAuthPluginTests(props map[string]string) (driver_infrastructure.Pl
 func TestIamAuthPluginConnect(t *testing.T) {
 	hostInfo, err := host_info_util.NewHostInfoBuilder().SetHost("database-test-name.cluster-XYZ.us-east-2.rds.amazonaws.com").SetPort(1234).Build()
 	assert.Nil(t, err)
-	mockConnFunc := func() (driver.Conn, error) { return &MockConn{nil, nil, nil, nil, true, 0, 0}, nil }
+	mockConnFunc := func() (driver.Conn, error) { return &MockConn{throwError: true}, nil }
 
 	props := map[string]string{
 		property_util.USER.Name:            "someUser",
@@ -65,7 +65,7 @@ func TestIamAuthPluginConnect(t *testing.T) {
 func TestIamAuthPluginConnectWithIamProps(t *testing.T) {
 	hostInfo, err := host_info_util.NewHostInfoBuilder().SetHost("database-test-name.cluster-XYZ.us-east-2.rds.amazonaws.com").SetPort(1234).Build()
 	assert.Nil(t, err)
-	mockConnFunc := func() (driver.Conn, error) { return &MockConn{nil, nil, nil, nil, true, 0, 0}, nil }
+	mockConnFunc := func() (driver.Conn, error) { return &MockConn{throwError: true}, nil }
 
 	props := map[string]string{
 		property_util.USER.Name:             "someUser",
@@ -93,7 +93,7 @@ func TestIamAuthPluginConnectWithIamProps(t *testing.T) {
 func TestIamAuthPluginConnectInvalidRegionError(t *testing.T) {
 	hostInfo, err := host_info_util.NewHostInfoBuilder().SetHost("mydatabasewithnoregion.com").SetPort(1234).Build()
 	assert.Nil(t, err)
-	mockConnFunc := func() (driver.Conn, error) { return &MockConn{nil, nil, nil, nil, true, 0, 0}, nil }
+	mockConnFunc := func() (driver.Conn, error) { return &MockConn{throwError: true}, nil }
 
 	props := map[string]string{
 		property_util.USER.Name:            "someUser",
@@ -113,7 +113,7 @@ func TestIamAuthPluginConnectInvalidRegionError(t *testing.T) {
 func TestIamAuthPluginConnectPopulatesEmptyTokenCache(t *testing.T) {
 	hostInfo, err := host_info_util.NewHostInfoBuilder().SetHost("database-test-name.cluster-XYZ.us-east-2.rds.amazonaws.com").SetPort(1234).Build()
 	assert.Nil(t, err)
-	mockConnFunc := func() (driver.Conn, error) { return &MockConn{nil, nil, nil, nil, true, 0, 0}, nil }
+	mockConnFunc := func() (driver.Conn, error) { return &MockConn{throwError: true}, nil }
 
 	props := map[string]string{
 		property_util.USER.Name:            "someUser",
@@ -134,7 +134,7 @@ func TestIamAuthPluginConnectPopulatesEmptyTokenCache(t *testing.T) {
 func TestIamAuthPluginConnectUsesCachedToken(t *testing.T) {
 	hostInfo, err := host_info_util.NewHostInfoBuilder().SetHost("database-test-name.cluster-XYZ.us-east-2.rds.amazonaws.com").SetPort(1234).Build()
 	assert.Nil(t, err)
-	mockConnFunc := func() (driver.Conn, error) { return &MockConn{nil, nil, nil, nil, true, 0, 0}, nil }
+	mockConnFunc := func() (driver.Conn, error) { return &MockConn{throwError: true}, nil }
 
 	props := map[string]string{
 		property_util.USER.Name:             "someUser",
@@ -168,7 +168,7 @@ func TestIamAuthPluginConnectUsesCachedToken(t *testing.T) {
 func TestIamAuthPluginConnectCacheExpiredToken(t *testing.T) {
 	hostInfo, err := host_info_util.NewHostInfoBuilder().SetHost("database-test-name.cluster-XYZ.us-east-2.rds.amazonaws.com").SetPort(1234).Build()
 	assert.Nil(t, err)
-	mockConnFunc := func() (driver.Conn, error) { return &MockConn{nil, nil, nil, nil, true, 0, 0}, nil }
+	mockConnFunc := func() (driver.Conn, error) { return &MockConn{throwError: true}, nil }
 
 	props := map[string]string{
 		property_util.USER.Name:             "someUser",
@@ -217,7 +217,7 @@ func TestIamAuthPluginConnectTtlExpiredCachedToken(t *testing.T) {
 			return nil, mockLoginError
 		} else {
 			mockConnFuncCallCounter++
-			return &MockConn{nil, nil, nil, nil, true, 0, 0}, nil
+			return &MockConn{throwError: true}, nil
 		}
 	}
 

--- a/test/mock_implementations.go
+++ b/test/mock_implementations.go
@@ -164,10 +164,6 @@ func (m *MockDriverConnection) Begin() (driver.Tx, error) {
 	return nil, nil
 }
 
-func (m *MockDriverConnection) IsValid() bool {
-	return true
-}
-
 func CreateTestPlugin(calls *[]string, id int, connection driver.Conn, err error, isBefore bool) driver_infrastructure.ConnectionPlugin {
 	if calls == nil {
 		calls = &[]string{}
@@ -234,6 +230,7 @@ type MockConn struct {
 	throwError         bool
 	closeCounter       int
 	execContextCounter int
+	isInvalid          bool
 }
 
 func (m *MockConn) Close() error {
@@ -258,7 +255,14 @@ func (m *MockConn) QueryContext(ctx context.Context, query string, args []driver
 
 func (m *MockConn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
 	m.execContextCounter++
-	return m.execResult, nil
+	if !m.throwError {
+		return m.execResult, nil
+	}
+	return nil, errors.New("test error")
+}
+
+func (m *MockConn) IsValid() bool {
+	return !m.isInvalid
 }
 
 func (m *MockConn) updateQueryRow(columns []string, row []driver.Value) {

--- a/test/okta_auth_plugin_test.go
+++ b/test/okta_auth_plugin_test.go
@@ -65,7 +65,7 @@ func TestGetOktaAuthPlugin(t *testing.T) {
 func TestOktaAuthPluginConnect(t *testing.T) {
 	hostInfo, err := host_info_util.NewHostInfoBuilder().SetHost("database-test-name.cluster-XYZ.us-east-2.rds.amazonaws.com").SetPort(1234).Build()
 	assert.NoError(t, err)
-	mockConnFunc := func() (driver.Conn, error) { return &MockConn{nil, nil, nil, nil, true, 0, 0}, nil }
+	mockConnFunc := func() (driver.Conn, error) { return &MockConn{throwError: true}, nil }
 
 	props := map[string]string{
 		property_util.DRIVER_PROTOCOL.Name: "postgresql",
@@ -82,7 +82,7 @@ func TestOktaAuthPluginConnect(t *testing.T) {
 func TestOktaAuthPluginForceConnect(t *testing.T) {
 	hostInfo, err := host_info_util.NewHostInfoBuilder().SetHost("database-test-name.cluster-XYZ.us-east-2.rds.amazonaws.com").SetPort(1234).Build()
 	assert.NoError(t, err)
-	mockConnFunc := func() (driver.Conn, error) { return &MockConn{nil, nil, nil, nil, true, 0, 0}, nil }
+	mockConnFunc := func() (driver.Conn, error) { return &MockConn{throwError: true}, nil }
 
 	props := map[string]string{
 		property_util.DRIVER_PROTOCOL.Name: "postgresql",
@@ -99,7 +99,7 @@ func TestOktaAuthPluginForceConnect(t *testing.T) {
 func TestOktaAuthPluginInvalidRegion(t *testing.T) {
 	hostInfo, err := host_info_util.NewHostInfoBuilder().SetHost("database-test-name.cluster-XYZ.invalid-region.rds.amazonaws.com").SetPort(1234).Build()
 	assert.NoError(t, err)
-	mockConnFunc := func() (driver.Conn, error) { return &MockConn{nil, nil, nil, nil, true, 0, 0}, nil }
+	mockConnFunc := func() (driver.Conn, error) { return &MockConn{throwError: true}, nil }
 
 	props := map[string]string{
 		property_util.DRIVER_PROTOCOL.Name: "postgresql",
@@ -114,7 +114,7 @@ func TestOktaAuthPluginInvalidRegion(t *testing.T) {
 func TestOktaAuthPluginValidRegionThroughIam(t *testing.T) {
 	hostInfo, err := host_info_util.NewHostInfoBuilder().SetHost("database-test-name.cluster-XYZ.invalid-region.rds.amazonaws.com").SetPort(1234).Build()
 	assert.NoError(t, err)
-	mockConnFunc := func() (driver.Conn, error) { return &MockConn{nil, nil, nil, nil, true, 0, 0}, nil }
+	mockConnFunc := func() (driver.Conn, error) { return &MockConn{throwError: true}, nil }
 
 	props := map[string]string{
 		property_util.DRIVER_PROTOCOL.Name: "postgresql",
@@ -134,7 +134,7 @@ func TestOktaAuthPluginCachedToken(t *testing.T) {
 	port := 1234
 	hostInfo, err := host_info_util.NewHostInfoBuilder().SetHost(host).SetPort(port).Build()
 	assert.NoError(t, err)
-	mockConnFunc := func() (driver.Conn, error) { return &MockConn{nil, nil, nil, nil, true, 0, 0}, nil }
+	mockConnFunc := func() (driver.Conn, error) { return &MockConn{throwError: true}, nil }
 
 	props := map[string]string{
 		property_util.DRIVER_PROTOCOL.Name: "postgresql",
@@ -161,7 +161,7 @@ func TestOktaAuthPluginCachedIamHostToken(t *testing.T) {
 	port := 1234
 	hostInfo, err := host_info_util.NewHostInfoBuilder().SetHost(host).SetPort(port).Build()
 	assert.NoError(t, err)
-	mockConnFunc := func() (driver.Conn, error) { return &MockConn{nil, nil, nil, nil, true, 0, 0}, nil }
+	mockConnFunc := func() (driver.Conn, error) { return &MockConn{throwError: true}, nil }
 	iamHost := "iamHost"
 	iamPort := 543
 	iamRegion := "us-east-1"
@@ -194,7 +194,7 @@ func TestOktaAuthPluginExpiredTokenWithIamHost(t *testing.T) {
 	port := 1234
 	hostInfo, err := host_info_util.NewHostInfoBuilder().SetHost(host).SetPort(port).Build()
 	assert.NoError(t, err)
-	mockConnFunc := func() (driver.Conn, error) { return &MockConn{nil, nil, nil, nil, true, 0, 0}, nil }
+	mockConnFunc := func() (driver.Conn, error) { return &MockConn{throwError: true}, nil }
 
 	iamHost := "iamHost"
 	iamRegion := "us-east-1"
@@ -227,7 +227,7 @@ func TestOktaAuthGenerateTokenFailure(t *testing.T) {
 	port := 1234
 	hostInfo, err := host_info_util.NewHostInfoBuilder().SetHost(host).SetPort(port).Build()
 	assert.NoError(t, err)
-	mockConnFunc := func() (driver.Conn, error) { return &MockConn{nil, nil, nil, nil, true, 0, 0}, nil }
+	mockConnFunc := func() (driver.Conn, error) { return &MockConn{throwError: true}, nil }
 
 	props := map[string]string{
 		property_util.DRIVER_PROTOCOL.Name: "postgresql",

--- a/test_framework/container/tests/efm_test.go
+++ b/test_framework/container/tests/efm_test.go
@@ -196,6 +196,7 @@ func TestEfmDisableAllInstancesDB(t *testing.T) {
 	close(queryChan)
 	require.NotNil(t, queryErr)
 	slog.Debug(fmt.Sprintf("Sleep query fails with error: %s.", queryErr.Error()))
+	assert.False(t, errors.Is(queryErr, context.DeadlineExceeded), "Sleep query should have failed due to connectivity loss")
 
 	// Re-enable connectivity
 	slog.Debug("Re-enabling all connectivity.")


### PR DESCRIPTION
### Summary

Updates check for if connection is closed to use internal flags in the underlying driver.

### Description

- Introduces a new connection parameter `failureDetectionProbeTimeoutMs`.
- Adds helper `IsReachable`.
### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
