### PR TITLE
test: disabled connectivity failover

### DIFF
--- a/driver_infrastructure/mysql_error_handler.go
+++ b/driver_infrastructure/mysql_error_handler.go
@@ -18,11 +18,18 @@ package driver_infrastructure
 
 import (
 	"errors"
-	"github.com/go-sql-driver/mysql"
 	"strings"
+
+	"github.com/go-sql-driver/mysql"
 )
 
 const SqlStateAccessError = "28000"
+
+var MySqlNetworkErrorMessages = []string{
+	"invalid connection",
+	"bad connection",
+	"broken pipe",
+}
 
 type MySQLErrorHandler struct {
 }
@@ -33,8 +40,10 @@ func (m MySQLErrorHandler) IsNetworkError(err error) bool {
 		return true
 	}
 
-	if strings.Contains(err.Error(), "invalid connection") {
-		return true
+	for _, networkError := range MySqlNetworkErrorMessages {
+		if strings.Contains(err.Error(), networkError) {
+			return true
+		}
 	}
 
 	return false

--- a/driver_infrastructure/pgx_error_handler.go
+++ b/driver_infrastructure/pgx_error_handler.go
@@ -18,9 +18,10 @@ package driver_infrastructure
 
 import (
 	"errors"
-	"github.com/jackc/pgx/v5/pgconn"
 	"slices"
 	"strings"
+
+	"github.com/jackc/pgx/v5/pgconn"
 )
 
 var AccessErrors = []string{
@@ -40,6 +41,12 @@ var NetworkErrors = []string{
 	"XX",
 }
 
+var PgNetworkErrorMessages = []string{
+	"unexpected EOF",
+	"use of closed network connection",
+	"broken pipe",
+}
+
 type PgxErrorHandler struct {
 }
 
@@ -49,11 +56,7 @@ func (p *PgxErrorHandler) IsNetworkError(err error) bool {
 		return true
 	}
 
-	if strings.Contains(err.Error(), "unexpected EOF") {
-		return true
-	}
-
-	for _, networkError := range NetworkErrors {
+	for _, networkError := range PgNetworkErrorMessages {
 		if strings.Contains(err.Error(), networkError) {
 			return true
 		}

--- a/test/efm_test.go
+++ b/test/efm_test.go
@@ -84,19 +84,19 @@ func TestMonitorServiceImpl(t *testing.T) {
 	val, ok := efm.EFM_MONITORS.Get(monitorKey, time.Minute)
 	assert.True(t, ok)
 	assert.NotNil(t, val)
+	monitor, ok := val.(*efm.MonitorImpl)
+	assert.True(t, ok)
 
 	state2, err := monitorService.StartMonitoring(&testConn, mockHostInfo, nil, 0, 0, 0)
 	assert.Nil(t, err)
+	assert.Equal(t, 2, len(monitor.NewStates))
 	// Monitoring on the same host should not increase the cache size.
 	assert.Equal(t, efm.EFM_MONITORS.Size(), 1)
 	assert.True(t, state2.IsActive())
 
-	monitor, ok := val.(*efm.MonitorImpl)
-	assert.True(t, ok)
 	monitoringConn := &MockDriverConnection{}
 	monitor.MonitoringConn = monitoringConn
 
-	assert.Equal(t, 2, len(monitor.NewStates))
 	time.Sleep(time.Second) // Let the newStates monitoring routine update.
 	assert.Equal(t, 2, len(monitor.ActiveStates))
 	assert.Equal(t, 0, len(monitor.NewStates))

--- a/test_framework/container/test_utils/proxy_helper.go
+++ b/test_framework/container/test_utils/proxy_helper.go
@@ -129,6 +129,44 @@ func DisableProxyConnectivity(proxyInfo ProxyInfo) {
 	}
 }
 
+func DisableAllProxies() {
+	env, err := GetCurrentTestEnvironment()
+	if err == nil {
+		for _, proxy := range env.proxies {
+			DisableProxy(proxy)
+		}
+	}
+}
+
+func DisableProxy(proxyInfo ProxyInfo) {
+	proxy := proxyInfo.proxy
+	if proxy != nil {
+		err := proxy.Disable()
+		if err != nil {
+			slog.Debug(fmt.Sprintf("Error disabling proxy %s:%d: %s.", proxyInfo.controlHost, proxyInfo.controlPort, err.Error()))
+		}
+	}
+}
+
+func EnableAllProxies() {
+	env, err := GetCurrentTestEnvironment()
+	if err == nil {
+		for _, proxy := range env.proxies {
+			EnableProxy(proxy)
+		}
+	}
+}
+
+func EnableProxy(proxyInfo ProxyInfo) {
+	proxy := proxyInfo.proxy
+	if proxy != nil {
+		err := proxy.Enable()
+		if err != nil {
+			slog.Debug(fmt.Sprintf("Error enabling proxy %s:%d: %s.", proxyInfo.controlHost, proxyInfo.controlPort, err.Error()))
+		}
+	}
+}
+
 func createProxyUrl(host string, port int) string {
 	return fmt.Sprintf("http://%s:%d", host, port)
 }

--- a/test_framework/container/tests/failover_db_test.go
+++ b/test_framework/container/tests/failover_db_test.go
@@ -18,7 +18,6 @@ package test
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 
 	"awssql/error_util"
@@ -171,7 +170,7 @@ func TestFailoverWriterInTransactionWithBegin(t *testing.T) {
 	defer test_utils.BasicCleanup(t.Name())
 	assert.Nil(t, err)
 	dsn := test_utils.GetDsn(environment, map[string]string{
-		"host":    environment.Info().DatabaseInfo.ClusterEndpoint,
+		"host":    environment.Info().DatabaseInfo.WriterInstanceEndpoint(),
 		"port":    strconv.Itoa(environment.Info().DatabaseInfo.InstanceEndpointPort),
 		"plugins": "failover",
 	})
@@ -180,9 +179,10 @@ func TestFailoverWriterInTransactionWithBegin(t *testing.T) {
 	assert.NotNil(t, db)
 	defer db.Close()
 
-	// Verify connection works.
-	err = db.Ping()
-	require.NoError(t, err, "Failed to open database connection.")
+	// Check that we are connected to the writer.
+	instanceId, err := test_utils.ExecuteInstanceQueryDB(environment.Info().Request.Engine, environment.Info().Request.Deployment, db)
+	assert.Nil(t, err)
+	require.True(t, auroraTestUtility.IsDbInstanceWriter(instanceId, ""))
 
 	// Create a test table to verify transaction rollback
 	_, err = db.Exec("DROP TABLE IF EXISTS test_failover_tx_rollback")
@@ -212,18 +212,114 @@ func TestFailoverWriterInTransactionWithBegin(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 0, count, "Transaction should have been rolled back, table should be empty.")
 
-	instanceId, err := test_utils.ExecuteInstanceQueryDB(environment.Info().Request.Engine, environment.Info().Request.Deployment, db)
+	assert.Nil(t, test_utils.VerifyClusterStatus())
+	environment, err = test_utils.GetCurrentTestEnvironment()
 	assert.Nil(t, err)
-	currWriterId, err := auroraTestUtility.GetClusterWriterInstanceId("")
+	cleanup_db, err := sql.Open("awssql", test_utils.GetDsn(environment, map[string]string{
+		"host": environment.Info().DatabaseInfo.WriterInstanceEndpoint(),
+		"port": strconv.Itoa(environment.Info().DatabaseInfo.InstanceEndpointPort),
+	}))
 	assert.Nil(t, err)
-	if instanceId != currWriterId {
-		slog.Error(fmt.Sprintf("We did not failover to the writer. Connected to: %s. Writer: %s.", instanceId, currWriterId))
-		db, err := sql.Open("awssql", dsn)
-		assert.Nil(t, err)
-		assert.NotNil(t, db)
-		defer db.Close()
-	}
+	assert.NotNil(t, cleanup_db)
+	defer cleanup_db.Close()
 
-	_, err = db.Exec("DROP TABLE IF EXISTS test_failover_tx_rollback")
+	// Check that we are connected to the writer.
+	instanceId, err = test_utils.ExecuteInstanceQueryDB(environment.Info().Request.Engine, environment.Info().Request.Deployment, cleanup_db)
 	assert.Nil(t, err)
+	require.True(t, auroraTestUtility.IsDbInstanceWriter(instanceId, ""))
+
+	_, err = cleanup_db.Exec("DROP TABLE IF EXISTS test_failover_tx_rollback")
+	assert.Nil(t, err)
+}
+
+func TestFailoverDisableProxies(t *testing.T) {
+	_, environment, err := failoverSetup(t)
+	defer test_utils.BasicCleanup(t.Name())
+	assert.Nil(t, err)
+	dsn := getDsnForTestsWithProxy(environment, environment.Info().ProxyDatabaseInfo.ClusterEndpoint, "failover")
+	db, err := sql.Open("awssql", dsn)
+	assert.Nil(t, err)
+	assert.NotNil(t, db)
+	defer db.Close()
+
+	// Verify connection works.
+	err = db.Ping()
+	require.NoError(t, err, "Failed to open database connection.")
+
+	// Start a long-running query in a goroutine
+	queryChan := make(chan error)
+	go func() {
+		// Execute a sleep query that will run for 10 seconds
+		sleepQuery := test_utils.GetSleepSql(environment.Info().Request.Engine, TEST_SLEEP_QUERY_SECONDS)
+
+		_, err := test_utils.ExecuteQueryDB(environment.Info().Request.Engine, db, sleepQuery, TEST_SLEEP_QUERY_TIMEOUT_SECONDS)
+		queryChan <- err
+	}()
+
+	// Wait a bit to ensure the query has started
+	time.Sleep(5 * time.Second)
+
+	// Disable connectivity while the sleep query is running
+	slog.Debug("Disabling all proxies.")
+	test_utils.DisableAllProxies()
+
+	// Wait for the query to complete and check the error
+	queryErr := <-queryChan
+	close(queryChan)
+	require.NotNil(t, queryErr)
+	assert.Equal(t, error_util.GetMessage("Failover.unableToRefreshHostList"), queryErr.Error())
+
+	// Re-enable connectivity
+	slog.Debug("Re-enabling all proxies.")
+	test_utils.EnableAllProxies()
+
+	newInstanceId, err := test_utils.ExecuteInstanceQueryDB(environment.Info().Request.Engine, environment.Info().Request.Deployment, db)
+	assert.Nil(t, err, "After connectivity is re-enabled new connections should not throw errors.")
+	assert.NotZero(t, newInstanceId)
+}
+
+func TestFailoverEfmDisableAllInstances(t *testing.T) {
+	_, environment, err := failoverSetup(t)
+	defer test_utils.BasicCleanup(t.Name())
+	assert.Nil(t, err)
+	dsn := getDsnForTestsWithProxy(environment, environment.Info().ProxyDatabaseInfo.ClusterEndpoint, "failover,efm")
+	db, err := sql.Open("awssql", dsn)
+	assert.Nil(t, err)
+	assert.NotNil(t, db)
+	defer db.Close()
+
+	// Verify connection works.
+	err = db.Ping()
+	require.NoError(t, err, "Failed to open database connection.")
+
+	// Start a long-running query in a goroutine
+	queryChan := make(chan error)
+	go func() {
+		// Execute a sleep query that will run for 10 seconds
+		sleepQuery := test_utils.GetSleepSql(environment.Info().Request.Engine, TEST_SLEEP_QUERY_SECONDS)
+
+		_, err := test_utils.ExecuteQueryDB(environment.Info().Request.Engine, db, sleepQuery, TEST_SLEEP_QUERY_TIMEOUT_SECONDS)
+		queryChan <- err
+	}()
+
+	// Wait a bit to ensure the query has started
+	time.Sleep(5 * time.Second)
+
+	// Disable connectivity while the sleep query is running
+	slog.Debug("Disabling all connectivity.")
+	test_utils.DisableAllConnectivity()
+
+	// Wait for the query to complete and check the error
+	queryErr := <-queryChan
+	close(queryChan)
+	require.NotNil(t, queryErr)
+	assert.Equal(t, error_util.GetMessage("Failover.unableToRefreshHostList"), queryErr.Error())
+
+	// Re-enable connectivity
+	slog.Debug("Re-enabling all connectivity.")
+	test_utils.EnableAllConnectivity(true)
+
+	newInstanceId, err := test_utils.ExecuteInstanceQueryDB(environment.Info().Request.Engine, environment.Info().Request.Deployment, db)
+	assert.Nil(t, err, "After connectivity is re-enabled new connections should not throw errors.")
+	assert.NotZero(t, newInstanceId)
 }


### PR DESCRIPTION
### Summary

Adds additional testing of failover recovery when connectivity is disabled.

### Description

- Adds integration tests for the failover plugin using toxiproxy to disable connectivity. 
- Updates check for writer change after triggering failover to not depend on an IP change.
- Refactors checks for writer change to occur concurrently. 
- Closes go routines created in integration tests. 
- Ensures connection to writer when creating and deleting tables for failover in transaction tests.

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
