### PR TITLE
fix: caching on setup go for actions

### DIFF
--- a/.github/workflows/aurora-performance.yml
+++ b/.github/workflows/aurora-performance.yml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: '1.24' 
+          cache-dependency-path: .test/go.sum
 
       - name: Configure AWS Credentials
         id: creds

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: '1.24'
+          cache-dependency-path: .test/go.sum
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/integration_tests_latest.yml
+++ b/.github/workflows/integration_tests_latest.yml
@@ -35,6 +35,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: '1.24'
+          cache-dependency-path: .test/go.sum
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:


### PR DESCRIPTION
### Summary

Fix github actions caching for setting up go

### Description

Fix gh actions cache for 
- aurora-performance.yml
- integrations-tests.yml
- integration-tests-latest.yml

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
