### PR TITLE
fix: set fail-fast to false so linting can run on all modules

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{fromJson(needs.get-list-of-go-modules.outputs.matrix)}}
+      fail-fast: false
     steps:
       - name: 'Clone repository'
         uses: actions/checkout@v4


### PR DESCRIPTION
### Summary

fix: set fail-fast to false so linting can run on all modules. This way, we can see all the errors at once

### Description


### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
