### PR TITLE
fix: dsn parsing issues

### DIFF
--- a/.test/test/rds_utils_test.go
+++ b/.test/test/rds_utils_test.go
@@ -17,14 +17,16 @@
 package test
 
 import (
-	"github.com/aws/aws-advanced-go-wrapper/awssql/utils"
 	"testing"
+
+	"github.com/aws/aws-advanced-go-wrapper/awssql/utils"
 
 	"github.com/stretchr/testify/assert"
 )
 
 const (
 	usEastRegionCluster               = "database-test-name.cluster-XYZ.us-east-2.rds.amazonaws.com"
+	usEastRegionClusterTrailingDot    = "database-test-name.cluster-XYZ.us-east-2.rds.amazonaws.com."
 	usEastRegionClusterReadOnly       = "database-test-name.cluster-ro-XYZ.us-east-2.rds.amazonaws.com"
 	usEastRegionInstance              = "instance-test-name.XYZ.us-east-2.rds.amazonaws.com"
 	usEastRegionProxy                 = "proxy-test-name.proxy-XYZ.us-east-2.rds.amazonaws.com"
@@ -32,24 +34,28 @@ const (
 	usEastRegionLimitlessDbShardGroup = "database-test-name.shardgrp-XYZ.us-east-2.rds.amazonaws.com"
 
 	chinaRegionCluster               = "database-test-name.cluster-XYZ.rds.cn-northwest-1.amazonaws.com.cn"
+	chinaRegionClusterTrailingDot    = "database-test-name.cluster-XYZ.rds.cn-northwest-1.amazonaws.com.cn."
 	chinaRegionClusterReadOnly       = "database-test-name.cluster-ro-XYZ.rds.cn-northwest-1.amazonaws.com.cn"
 	chinaRegionInstance              = "instance-test-name.XYZ.rds.cn-northwest-1.amazonaws.com.cn"
 	chinaRegionProxy                 = "proxy-test-name.proxy-XYZ.rds.cn-northwest-1.amazonaws.com.cn"
 	chinaRegionCustomDomain          = "custom-test-name.cluster-custom-XYZ.rds.cn-northwest-1.amazonaws.com.cn"
 	chinaRegionLimitlessDbShardGroup = "database-test-name.shardgrp-XYZ.rds.cn-northwest-1.amazonaws.com.cn"
 
-	oldChinaRegionCluster               = "database-test-name.cluster-XYZ.cn-northwest-1.rds.amazonaws.com.cn"
-	oldChinaRegionClusterReadOnly       = "database-test-name.cluster-ro-XYZ.cn-northwest-1.rds.amazonaws.com.cn"
-	oldChinaRegionInstance              = "instance-test-name.XYZ.cn-northwest-1.rds.amazonaws.com.cn"
-	oldChinaRegionProxy                 = "proxy-test-name.proxy-XYZ.cn-northwest-1.rds.amazonaws.com.cn"
-	oldChinaRegionCustomDomain          = "custom-test-name.cluster-custom-XYZ.cn-northwest-1.rds.amazonaws.com.cn"
-	oldChinaRegionLimitlessDbShardGroup = "database-test-name.shardgrp-XYZ.cn-northwest-1.rds.amazonaws.com.cn"
+	oldChinaRegionCluster                          = "database-test-name.cluster-XYZ.cn-northwest-1.rds.amazonaws.com.cn"
+	oldChinaRegionClusterTrailingDot               = "database-test-name.cluster-XYZ.cn-northwest-1.rds.amazonaws.com.cn."
+	oldChinaRegionClusterReadOnly                  = "database-test-name.cluster-ro-XYZ.cn-northwest-1.rds.amazonaws.com.cn"
+	oldChinaRegionInstance                         = "instance-test-name.XYZ.cn-northwest-1.rds.amazonaws.com.cn"
+	oldChinaRegionProxy                            = "proxy-test-name.proxy-XYZ.cn-northwest-1.rds.amazonaws.com.cn"
+	oldChinaRegionCustomDomain                     = "custom-test-name.cluster-custom-XYZ.cn-northwest-1.rds.amazonaws.com.cn"
+	oldChinaRegionLimitlessDbShardGroup            = "database-test-name.shardgrp-XYZ.cn-northwest-1.rds.amazonaws.com.cn"
+	oldChinaRegionLimitlessDbShardGroupTrailingDot = "database-test-name.shardgrp-XYZ.cn-northwest-1.rds.amazonaws.com.cn."
 
 	extraRdsChinaPath      = "database-test-name.cluster-XYZ.rds.cn-northwest-1.rds.amazonaws.com.cn" //nolint:unused
 	missingCnChinaPath     = "database-test-name.cluster-XYZ.rds.cn-northwest-1.amazonaws.com"        //nolint:unused
 	missingRegionChinaPath = "database-test-name.cluster-XYZ.rds.amazonaws.com.cn"                    //nolint:unused
 
-	usEastRegionElbUrl = "elb-name.elb.us-east-2.amazonaws.com"
+	usEastRegionElbUrl            = "elb-name.elb.us-east-2.amazonaws.com"
+	usEastRegionElbUrlTrailingDot = "elb-name.elb.us-east-2.amazonaws.com."
 
 	usIsobEastRegionCluster               = "database-test-name.cluster-XYZ.rds.us-isob-east-1.sc2s.sgov.gov"
 	usIsobEastRegionClusterReadOnly       = "database-test-name.cluster-ro-XYZ.rds.us-isob-east-1.sc2s.sgov.gov"
@@ -60,6 +66,7 @@ const (
 
 	usGovEastRegionCluster               = "database-test-name.cluster-XYZ.rds.us-gov-east-1.amazonaws.com"
 	usIsoEastRegionCluster               = "database-test-name.cluster-XYZ.rds.us-iso-east-1.c2s.ic.gov"
+	usIsoEastRegionClusterTrailingDot    = "database-test-name.cluster-XYZ.rds.us-iso-east-1.c2s.ic.gov."
 	usIsoEastRegionClusterReadOnly       = "database-test-name.cluster-ro-XYZ.rds.us-iso-east-1.c2s.ic.gov"
 	usIsoEastRegionInstance              = "instance-test-name.XYZ.rds.us-iso-east-1.c2s.ic.gov"
 	usIsoEastRegionProxy                 = "proxy-test-name.proxy-XYZ.rds.us-iso-east-1.c2s.ic.gov"
@@ -69,11 +76,13 @@ const (
 
 func TestIsRdsDns(t *testing.T) {
 	assert.True(t, utils.IsRdsDns(usEastRegionCluster))
+	assert.True(t, utils.IsRdsDns(usEastRegionClusterTrailingDot))
 	assert.True(t, utils.IsRdsDns(usEastRegionClusterReadOnly))
 	assert.True(t, utils.IsRdsDns(usEastRegionInstance))
 	assert.True(t, utils.IsRdsDns(usEastRegionProxy))
 	assert.True(t, utils.IsRdsDns(usEastRegionCustomDomain))
 	assert.False(t, utils.IsRdsDns(usEastRegionElbUrl))
+	assert.False(t, utils.IsRdsDns(usEastRegionElbUrlTrailingDot))
 	assert.True(t, utils.IsRdsDns(usEastRegionLimitlessDbShardGroup))
 
 	assert.True(t, utils.IsRdsDns(usIsobEastRegionCluster))
@@ -84,6 +93,7 @@ func TestIsRdsDns(t *testing.T) {
 	assert.True(t, utils.IsRdsDns(usIsobEastRegionLimitlessDbShardGroup))
 
 	assert.True(t, utils.IsRdsDns(usIsoEastRegionCluster))
+	assert.True(t, utils.IsRdsDns(usIsoEastRegionClusterTrailingDot))
 	assert.True(t, utils.IsRdsDns(usIsoEastRegionClusterReadOnly))
 	assert.True(t, utils.IsRdsDns(usIsoEastRegionInstance))
 	assert.True(t, utils.IsRdsDns(usIsoEastRegionProxy))
@@ -91,6 +101,7 @@ func TestIsRdsDns(t *testing.T) {
 	assert.True(t, utils.IsRdsDns(usIsoEastRegionLimitlessDbShardGroup))
 
 	assert.True(t, utils.IsRdsDns(chinaRegionCluster))
+	assert.True(t, utils.IsRdsDns(chinaRegionClusterTrailingDot))
 	assert.True(t, utils.IsRdsDns(chinaRegionClusterReadOnly))
 	assert.True(t, utils.IsRdsDns(chinaRegionInstance))
 	assert.True(t, utils.IsRdsDns(chinaRegionProxy))
@@ -98,20 +109,24 @@ func TestIsRdsDns(t *testing.T) {
 	assert.True(t, utils.IsRdsDns(chinaRegionLimitlessDbShardGroup))
 
 	assert.True(t, utils.IsRdsDns(oldChinaRegionCluster))
+	assert.True(t, utils.IsRdsDns(oldChinaRegionClusterTrailingDot))
 	assert.True(t, utils.IsRdsDns(oldChinaRegionClusterReadOnly))
 	assert.True(t, utils.IsRdsDns(oldChinaRegionInstance))
 	assert.True(t, utils.IsRdsDns(oldChinaRegionProxy))
 	assert.True(t, utils.IsRdsDns(oldChinaRegionCustomDomain))
 	assert.True(t, utils.IsRdsDns(oldChinaRegionLimitlessDbShardGroup))
+	assert.True(t, utils.IsRdsDns(oldChinaRegionLimitlessDbShardGroupTrailingDot))
 }
 
 func TestIsWriterClusterDns(t *testing.T) {
 	assert.True(t, utils.IsWriterClusterDns(usEastRegionCluster))
+	assert.True(t, utils.IsWriterClusterDns(usEastRegionClusterTrailingDot))
 	assert.False(t, utils.IsWriterClusterDns(usEastRegionClusterReadOnly))
 	assert.False(t, utils.IsWriterClusterDns(usEastRegionInstance))
 	assert.False(t, utils.IsWriterClusterDns(usEastRegionProxy))
 	assert.False(t, utils.IsWriterClusterDns(usEastRegionCustomDomain))
 	assert.False(t, utils.IsWriterClusterDns(usEastRegionElbUrl))
+	assert.False(t, utils.IsWriterClusterDns(usEastRegionElbUrlTrailingDot))
 	assert.False(t, utils.IsWriterClusterDns(usEastRegionLimitlessDbShardGroup))
 
 	assert.True(t, utils.IsWriterClusterDns(usIsobEastRegionCluster))
@@ -122,6 +137,7 @@ func TestIsWriterClusterDns(t *testing.T) {
 	assert.False(t, utils.IsWriterClusterDns(usIsobEastRegionLimitlessDbShardGroup))
 
 	assert.True(t, utils.IsWriterClusterDns(usIsoEastRegionCluster))
+	assert.True(t, utils.IsWriterClusterDns(usIsoEastRegionClusterTrailingDot))
 	assert.False(t, utils.IsWriterClusterDns(usIsoEastRegionClusterReadOnly))
 	assert.False(t, utils.IsWriterClusterDns(usIsoEastRegionInstance))
 	assert.False(t, utils.IsWriterClusterDns(usIsoEastRegionProxy))
@@ -129,6 +145,7 @@ func TestIsWriterClusterDns(t *testing.T) {
 	assert.False(t, utils.IsWriterClusterDns(usIsoEastRegionLimitlessDbShardGroup))
 
 	assert.True(t, utils.IsWriterClusterDns(chinaRegionCluster))
+	assert.True(t, utils.IsWriterClusterDns(chinaRegionClusterTrailingDot))
 	assert.False(t, utils.IsWriterClusterDns(chinaRegionClusterReadOnly))
 	assert.False(t, utils.IsWriterClusterDns(chinaRegionInstance))
 	assert.False(t, utils.IsWriterClusterDns(chinaRegionProxy))
@@ -136,20 +153,24 @@ func TestIsWriterClusterDns(t *testing.T) {
 	assert.False(t, utils.IsWriterClusterDns(chinaRegionLimitlessDbShardGroup))
 
 	assert.True(t, utils.IsWriterClusterDns(oldChinaRegionCluster))
+	assert.True(t, utils.IsWriterClusterDns(oldChinaRegionClusterTrailingDot))
 	assert.False(t, utils.IsWriterClusterDns(oldChinaRegionClusterReadOnly))
 	assert.False(t, utils.IsWriterClusterDns(oldChinaRegionInstance))
 	assert.False(t, utils.IsWriterClusterDns(oldChinaRegionProxy))
 	assert.False(t, utils.IsWriterClusterDns(oldChinaRegionCustomDomain))
 	assert.False(t, utils.IsWriterClusterDns(oldChinaRegionLimitlessDbShardGroup))
+	assert.False(t, utils.IsWriterClusterDns(oldChinaRegionLimitlessDbShardGroupTrailingDot))
 }
 
 func TestIsReaderClusterDns(t *testing.T) {
 	assert.False(t, utils.IsReaderClusterDns(usEastRegionCluster))
+	assert.False(t, utils.IsReaderClusterDns(usEastRegionClusterTrailingDot))
 	assert.True(t, utils.IsReaderClusterDns(usEastRegionClusterReadOnly))
 	assert.False(t, utils.IsReaderClusterDns(usEastRegionInstance))
 	assert.False(t, utils.IsReaderClusterDns(usEastRegionProxy))
 	assert.False(t, utils.IsReaderClusterDns(usEastRegionCustomDomain))
 	assert.False(t, utils.IsReaderClusterDns(usEastRegionElbUrl))
+	assert.False(t, utils.IsReaderClusterDns(usEastRegionElbUrlTrailingDot))
 	assert.False(t, utils.IsReaderClusterDns(usEastRegionLimitlessDbShardGroup))
 
 	assert.False(t, utils.IsReaderClusterDns(usIsobEastRegionCluster))
@@ -160,6 +181,7 @@ func TestIsReaderClusterDns(t *testing.T) {
 	assert.False(t, utils.IsReaderClusterDns(usIsobEastRegionLimitlessDbShardGroup))
 
 	assert.False(t, utils.IsReaderClusterDns(usIsoEastRegionCluster))
+	assert.False(t, utils.IsReaderClusterDns(usIsoEastRegionClusterTrailingDot))
 	assert.True(t, utils.IsReaderClusterDns(usIsoEastRegionClusterReadOnly))
 	assert.False(t, utils.IsReaderClusterDns(usIsoEastRegionInstance))
 	assert.False(t, utils.IsReaderClusterDns(usIsoEastRegionProxy))
@@ -167,6 +189,7 @@ func TestIsReaderClusterDns(t *testing.T) {
 	assert.False(t, utils.IsReaderClusterDns(usIsoEastRegionLimitlessDbShardGroup))
 
 	assert.False(t, utils.IsReaderClusterDns(chinaRegionCluster))
+	assert.False(t, utils.IsReaderClusterDns(chinaRegionClusterTrailingDot))
 	assert.True(t, utils.IsReaderClusterDns(chinaRegionClusterReadOnly))
 	assert.False(t, utils.IsReaderClusterDns(chinaRegionInstance))
 	assert.False(t, utils.IsReaderClusterDns(chinaRegionProxy))
@@ -174,20 +197,24 @@ func TestIsReaderClusterDns(t *testing.T) {
 	assert.False(t, utils.IsReaderClusterDns(chinaRegionLimitlessDbShardGroup))
 
 	assert.False(t, utils.IsReaderClusterDns(oldChinaRegionCluster))
+	assert.False(t, utils.IsReaderClusterDns(oldChinaRegionClusterTrailingDot))
 	assert.True(t, utils.IsReaderClusterDns(oldChinaRegionClusterReadOnly))
 	assert.False(t, utils.IsReaderClusterDns(oldChinaRegionInstance))
 	assert.False(t, utils.IsReaderClusterDns(oldChinaRegionProxy))
 	assert.False(t, utils.IsReaderClusterDns(oldChinaRegionCustomDomain))
 	assert.False(t, utils.IsReaderClusterDns(oldChinaRegionLimitlessDbShardGroup))
+	assert.False(t, utils.IsReaderClusterDns(oldChinaRegionLimitlessDbShardGroupTrailingDot))
 }
 
 func TestIsLimitlessDbShardGroupDns(t *testing.T) {
 	assert.False(t, utils.IsLimitlessDbShardGroupDns(usEastRegionCluster))
+	assert.False(t, utils.IsLimitlessDbShardGroupDns(usEastRegionClusterTrailingDot))
 	assert.False(t, utils.IsLimitlessDbShardGroupDns(usEastRegionClusterReadOnly))
 	assert.False(t, utils.IsLimitlessDbShardGroupDns(usEastRegionInstance))
 	assert.False(t, utils.IsLimitlessDbShardGroupDns(usEastRegionProxy))
 	assert.False(t, utils.IsLimitlessDbShardGroupDns(usEastRegionCustomDomain))
 	assert.False(t, utils.IsLimitlessDbShardGroupDns(usEastRegionElbUrl))
+	assert.False(t, utils.IsLimitlessDbShardGroupDns(usEastRegionElbUrlTrailingDot))
 	assert.True(t, utils.IsLimitlessDbShardGroupDns(usEastRegionLimitlessDbShardGroup))
 
 	assert.False(t, utils.IsLimitlessDbShardGroupDns(usIsobEastRegionCluster))
@@ -198,6 +225,7 @@ func TestIsLimitlessDbShardGroupDns(t *testing.T) {
 	assert.True(t, utils.IsLimitlessDbShardGroupDns(usIsobEastRegionLimitlessDbShardGroup))
 
 	assert.False(t, utils.IsLimitlessDbShardGroupDns(usIsoEastRegionCluster))
+	assert.False(t, utils.IsLimitlessDbShardGroupDns(usIsoEastRegionClusterTrailingDot))
 	assert.False(t, utils.IsLimitlessDbShardGroupDns(usIsoEastRegionClusterReadOnly))
 	assert.False(t, utils.IsLimitlessDbShardGroupDns(usIsoEastRegionInstance))
 	assert.False(t, utils.IsLimitlessDbShardGroupDns(usIsoEastRegionProxy))
@@ -205,6 +233,7 @@ func TestIsLimitlessDbShardGroupDns(t *testing.T) {
 	assert.True(t, utils.IsLimitlessDbShardGroupDns(usIsoEastRegionLimitlessDbShardGroup))
 
 	assert.False(t, utils.IsLimitlessDbShardGroupDns(chinaRegionCluster))
+	assert.False(t, utils.IsLimitlessDbShardGroupDns(chinaRegionClusterTrailingDot))
 	assert.False(t, utils.IsLimitlessDbShardGroupDns(chinaRegionClusterReadOnly))
 	assert.False(t, utils.IsLimitlessDbShardGroupDns(chinaRegionInstance))
 	assert.False(t, utils.IsLimitlessDbShardGroupDns(chinaRegionProxy))
@@ -212,11 +241,13 @@ func TestIsLimitlessDbShardGroupDns(t *testing.T) {
 	assert.True(t, utils.IsLimitlessDbShardGroupDns(chinaRegionLimitlessDbShardGroup))
 
 	assert.False(t, utils.IsLimitlessDbShardGroupDns(oldChinaRegionCluster))
+	assert.False(t, utils.IsLimitlessDbShardGroupDns(oldChinaRegionClusterTrailingDot))
 	assert.False(t, utils.IsLimitlessDbShardGroupDns(oldChinaRegionClusterReadOnly))
 	assert.False(t, utils.IsLimitlessDbShardGroupDns(oldChinaRegionInstance))
 	assert.False(t, utils.IsLimitlessDbShardGroupDns(oldChinaRegionProxy))
 	assert.False(t, utils.IsLimitlessDbShardGroupDns(oldChinaRegionCustomDomain))
 	assert.True(t, utils.IsLimitlessDbShardGroupDns(oldChinaRegionLimitlessDbShardGroup))
+	assert.True(t, utils.IsLimitlessDbShardGroupDns(oldChinaRegionLimitlessDbShardGroupTrailingDot))
 }
 
 func TestGetRdsRegion(t *testing.T) {

--- a/awssql/utils/rds_utils.go
+++ b/awssql/utils/rds_utils.go
@@ -28,25 +28,25 @@ var (
 		"(?i)^(?P<instance>.+)\\." +
 			"(?P<dns>proxy-|cluster-|cluster-ro-|cluster-custom-|shardgrp-)?" +
 			"(?P<domain>[a-zA-Z0-9]+\\.(?P<region>[a-zA-Z0-9\\-]+)" +
-			"\\.rds\\.amazonaws\\.com)$")
+			"\\.rds\\.amazonaws\\.com\\.?)$")
 
 	AURORA_CHINA_DNS_PATTERN = regexp.MustCompile(
 		"(?i)^(?P<instance>.+)\\." +
 			"(?P<dns>proxy-|cluster-|cluster-ro-|cluster-custom-|shardgrp-)?" +
 			"(?P<domain>[a-zA-Z0-9]+\\.rds\\.(?P<region>[a-zA-Z0-9\\-]+)" +
-			"\\.amazonaws\\.com\\.cn)$")
+			"\\.amazonaws\\.com\\.cn\\.?)$")
 
 	AURORA_OLD_CHINA_DNS_PATTERN = regexp.MustCompile(
 		"(?i)^(?P<instance>.+)\\." +
 			"(?P<dns>proxy-|cluster-|cluster-ro-|cluster-custom-|shardgrp-)?" +
 			"(?P<domain>[a-zA-Z0-9]+\\.(?P<region>[a-zA-Z0-9\\-]+)" +
-			"\\.rds\\.amazonaws\\.com\\.cn)$")
+			"\\.rds\\.amazonaws\\.com\\.cn\\.?)$")
 
 	AURORA_GOV_DNS_PATTERN = regexp.MustCompile(
 		"(?i)^(?<instance>.+)\\." +
 			"(?P<dns>proxy-|cluster-|cluster-ro-|cluster-custom-|shardgrp-)?" +
 			"(?P<domain>[a-zA-Z0-9]+\\.rds\\.(?P<region>[a-zA-Z0-9\\-]+)" +
-			"\\.(amazonaws\\.com|c2s\\.ic\\.gov|sc2s\\.sgov\\.gov))$")
+			"\\.(amazonaws\\.com\\.?|c2s\\.ic\\.gov\\.?|sc2s\\.sgov\\.gov\\.?))$")
 
 	IP_V4_REGEXP = regexp.MustCompile(
 		"^(([1-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){1}" +


### PR DESCRIPTION
### Summary

This PR fixes several issues with the dsn parser
- Fix trailing spaces issues
- Fix having parameters with `/` character for pgx key word value dsn 
- Accept urls with trailing `.` (also fix it in `isRdsUtil`)
- Accept url with trailing `/`



### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
