### PR TITLE
fix: throw underlying driver error in failover

### DIFF
--- a/awssql/plugins/stale_dns_helper.go
+++ b/awssql/plugins/stale_dns_helper.go
@@ -19,12 +19,13 @@ package plugins
 import (
 	"database/sql/driver"
 	"fmt"
+	"log/slog"
+	"net"
+
 	"github.com/aws/aws-advanced-go-wrapper/awssql/driver_infrastructure"
 	"github.com/aws/aws-advanced-go-wrapper/awssql/error_util"
 	"github.com/aws/aws-advanced-go-wrapper/awssql/host_info_util"
 	"github.com/aws/aws-advanced-go-wrapper/awssql/utils"
-	"log/slog"
-	"net"
 )
 
 type StaleDnsHelper struct {
@@ -43,6 +44,10 @@ func (s *StaleDnsHelper) GetVerifiedConnection(
 
 	if !utils.IsWriterClusterDns(host) {
 		return conn, err
+	}
+
+	if err != nil {
+		return nil, err
 	}
 
 	ip, ipErr := net.LookupIP(host)


### PR DESCRIPTION
### Summary

fix: throw underlying driver error in failover

### Description

Previously, if we had an iniital connection issue, we did not throw the underlying error. Instead, we threw "Unable to establish a SQL connection due to an unexpected error.".  This is because we do not check the error from GetVerifiedConnection upon initial connection.

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
