### PR TITLE
fix: concurrent map access

### DIFF
--- a/.test/test/aws_secrets_manager_connection_plugin_test.go
+++ b/.test/test/aws_secrets_manager_connection_plugin_test.go
@@ -49,7 +49,11 @@ func beforeAwsSecretsManagerConnectionPluginTests(props map[string]string) drive
 func TestAwsSecretsManagerConnectionPluginConnect(t *testing.T) {
 	hostInfo, err := host_info_util.NewHostInfoBuilder().SetHost("database-test-name.cluster-XYZ.us-east-2.rds.amazonaws.com").SetPort(1234).Build()
 	assert.Nil(t, err)
-	mockConnFunc := func() (driver.Conn, error) { return &MockConn{throwError: true}, nil }
+	var resultProps map[string]string
+	mockConnFunc := func(props map[string]string) (driver.Conn, error) {
+		resultProps = props
+		return &MockConn{throwError: true}, nil
+	}
 
 	props := map[string]string{
 		property_util.SECRETS_MANAGER_REGION.Name:    "us-west-2",
@@ -63,14 +67,18 @@ func TestAwsSecretsManagerConnectionPluginConnect(t *testing.T) {
 	_, err = awsSecretsManagerConnectionPlugin.Connect(hostInfo, props, false, mockConnFunc)
 
 	assert.Nil(t, err)
-	assert.Equal(t, "testuser", props[property_util.USER.Name])
-	assert.Equal(t, "testpassword", props[property_util.PASSWORD.Name])
+	assert.Equal(t, "testuser", resultProps[property_util.USER.Name])
+	assert.Equal(t, "testpassword", resultProps[property_util.PASSWORD.Name])
 }
 
 func TestAwsSecretsManagerConnectionPluginForceConnect(t *testing.T) {
 	hostInfo, err := host_info_util.NewHostInfoBuilder().SetHost("database-test-name.cluster-XYZ.us-east-2.rds.amazonaws.com").SetPort(1234).Build()
 	assert.Nil(t, err)
-	mockConnFunc := func() (driver.Conn, error) { return &MockConn{throwError: true}, nil }
+	var resultProps map[string]string
+	mockConnFunc := func(props map[string]string) (driver.Conn, error) {
+		resultProps = props
+		return &MockConn{throwError: true}, nil
+	}
 
 	props := map[string]string{
 		property_util.SECRETS_MANAGER_REGION.Name:    "us-west-2",
@@ -84,14 +92,18 @@ func TestAwsSecretsManagerConnectionPluginForceConnect(t *testing.T) {
 	_, err = awsSecretsManagerConnectionPlugin.ForceConnect(hostInfo, props, false, mockConnFunc)
 
 	assert.Nil(t, err)
-	assert.Equal(t, "testuser", props[property_util.USER.Name])
-	assert.Equal(t, "testpassword", props[property_util.PASSWORD.Name])
+	assert.Equal(t, "testuser", resultProps[property_util.USER.Name])
+	assert.Equal(t, "testpassword", resultProps[property_util.PASSWORD.Name])
 }
 
 func TestAwsSecretsManagerConnectionPluginProps(t *testing.T) {
 	hostInfo, err := host_info_util.NewHostInfoBuilder().SetHost("database-test-name.cluster-XYZ.us-east-2.rds.amazonaws.com").SetPort(1234).Build()
 	assert.Nil(t, err)
-	mockConnFunc := func() (driver.Conn, error) { return &MockConn{throwError: true}, nil }
+	var resultProps map[string]string
+	mockConnFunc := func(props map[string]string) (driver.Conn, error) {
+		resultProps = props
+		return &MockConn{throwError: true}, nil
+	}
 
 	props := map[string]string{
 		property_util.SECRETS_MANAGER_REGION.Name:    "us-west-2",
@@ -106,9 +118,9 @@ func TestAwsSecretsManagerConnectionPluginProps(t *testing.T) {
 	_, err = awsSecretsManagerConnectionPlugin.ForceConnect(hostInfo, props, false, mockConnFunc)
 
 	assert.Nil(t, err)
-	assert.Equal(t, "testuser", props[property_util.USER.Name])
-	assert.Equal(t, "testpassword", props[property_util.PASSWORD.Name])
-	assert.Equal(t, "https://someEndpoint.com", props[property_util.SECRETS_MANAGER_ENDPOINT.Name])
+	assert.Equal(t, "testuser", resultProps[property_util.USER.Name])
+	assert.Equal(t, "testpassword", resultProps[property_util.PASSWORD.Name])
+	assert.Equal(t, "https://someEndpoint.com", resultProps[property_util.SECRETS_MANAGER_ENDPOINT.Name])
 }
 
 func TestAwsSecretsManagerConnectionPluginMissingSecretId(t *testing.T) {
@@ -169,7 +181,11 @@ func TestAwsSecretsManagerConnectionPluginValidIdInvalidRegion(t *testing.T) {
 func TestAwsSecretsManagerConnectionPluginValidRegionThroughArn(t *testing.T) {
 	hostInfo, err := host_info_util.NewHostInfoBuilder().SetHost("database-test-name.cluster-XYZ.us-east-2.rds.amazonaws.com").SetPort(1234).Build()
 	assert.Nil(t, err)
-	mockConnFunc := func() (driver.Conn, error) { return &MockConn{throwError: true}, nil }
+	var resultProps map[string]string
+	mockConnFunc := func(props map[string]string) (driver.Conn, error) {
+		resultProps = props
+		return &MockConn{throwError: true}, nil
+	}
 
 	props := map[string]string{
 		property_util.SECRETS_MANAGER_SECRET_ID.Name: "arn:aws:secretsmanager:us-west-2:account-id:secret:default",
@@ -182,8 +198,8 @@ func TestAwsSecretsManagerConnectionPluginValidRegionThroughArn(t *testing.T) {
 	_, err = awsSecretsManagerConnectionPlugin.ForceConnect(hostInfo, props, false, mockConnFunc)
 
 	assert.Nil(t, err)
-	assert.Equal(t, "testuser", props[property_util.USER.Name])
-	assert.Equal(t, "testpassword", props[property_util.PASSWORD.Name])
+	assert.Equal(t, "testuser", resultProps[property_util.USER.Name])
+	assert.Equal(t, "testpassword", resultProps[property_util.PASSWORD.Name])
 }
 
 func TestAwsSecretsManagerConnectionPluginInvalidEndpoint(t *testing.T) {
@@ -207,7 +223,11 @@ func TestAwsSecretsManagerConnectionPluginCacheSize1(t *testing.T) {
 
 	hostInfo, err := host_info_util.NewHostInfoBuilder().SetHost("database-test-name.cluster-XYZ.us-east-2.rds.amazonaws.com").SetPort(1234).Build()
 	assert.Nil(t, err)
-	mockConnFunc := func() (driver.Conn, error) { return &MockConn{throwError: true}, nil }
+	var resultProps map[string]string
+	mockConnFunc := func(props map[string]string) (driver.Conn, error) {
+		resultProps = props
+		return &MockConn{throwError: true}, nil
+	}
 
 	props := map[string]string{
 		property_util.SECRETS_MANAGER_REGION.Name:    "us-west-2",
@@ -221,15 +241,19 @@ func TestAwsSecretsManagerConnectionPluginCacheSize1(t *testing.T) {
 	_, err = awsSecretsManagerConnectionPlugin.ForceConnect(hostInfo, props, false, mockConnFunc)
 
 	assert.Nil(t, err)
-	assert.Equal(t, "testuser", props[property_util.USER.Name])
-	assert.Equal(t, "testpassword", props[property_util.PASSWORD.Name])
+	assert.Equal(t, "testuser", resultProps[property_util.USER.Name])
+	assert.Equal(t, "testpassword", resultProps[property_util.PASSWORD.Name])
 	assert.Equal(t, 1, aws_secrets_manager.SecretsCache.Size())
 }
 
 func TestAwsSecretsManagerConnectionPluginUsingExpiredSecret(t *testing.T) {
 	hostInfo, err := host_info_util.NewHostInfoBuilder().SetHost("database-test-name.cluster-XYZ.us-east-2.rds.amazonaws.com").SetPort(1234).Build()
 	assert.Nil(t, err)
-	mockConnFunc := func() (driver.Conn, error) { return &MockConn{throwError: true}, nil }
+	var resultProps map[string]string
+	mockConnFunc := func(props map[string]string) (driver.Conn, error) {
+		resultProps = props
+		return &MockConn{throwError: true}, nil
+	}
 	secretId := "myId"
 	region := "us-west-2"
 	cachedUsername := "cachedUsername"
@@ -255,15 +279,19 @@ func TestAwsSecretsManagerConnectionPluginUsingExpiredSecret(t *testing.T) {
 	_, err = awsSecretsManagerConnectionPlugin.Connect(hostInfo, props, false, mockConnFunc)
 
 	assert.Nil(t, err)
-	assert.Equal(t, "testuser", props[property_util.USER.Name])
-	assert.Equal(t, "testpassword", props[property_util.PASSWORD.Name])
+	assert.Equal(t, "testuser", resultProps[property_util.USER.Name])
+	assert.Equal(t, "testpassword", resultProps[property_util.PASSWORD.Name])
 	assert.Equal(t, 1, aws_secrets_manager.SecretsCache.Size())
 }
 
 func TestAwsSecretsManagerConnectionPluginConnectingUsingCache(t *testing.T) {
 	hostInfo, err := host_info_util.NewHostInfoBuilder().SetHost("database-test-name.cluster-XYZ.us-east-2.rds.amazonaws.com").SetPort(1234).Build()
 	assert.Nil(t, err)
-	mockConnFunc := func() (driver.Conn, error) { return &MockConn{throwError: true}, nil }
+	var resultProps map[string]string
+	mockConnFunc := func(props map[string]string) (driver.Conn, error) {
+		resultProps = props
+		return &MockConn{throwError: true}, nil
+	}
 	secretId := "myId"
 	region := "us-west-2"
 	cachedUsername := "cachedUsername"
@@ -289,15 +317,15 @@ func TestAwsSecretsManagerConnectionPluginConnectingUsingCache(t *testing.T) {
 	_, err = awsSecretsManagerConnectionPlugin.Connect(hostInfo, props, false, mockConnFunc)
 
 	assert.Nil(t, err)
-	assert.Equal(t, cachedUsername, props[property_util.USER.Name])
-	assert.Equal(t, cachedPassword, props[property_util.PASSWORD.Name])
+	assert.Equal(t, cachedUsername, resultProps[property_util.USER.Name])
+	assert.Equal(t, cachedPassword, resultProps[property_util.PASSWORD.Name])
 	assert.Equal(t, 1, aws_secrets_manager.SecretsCache.Size())
 }
 
 func TestAwsSecretsManagerConnectionPluginMultipleConnectionsCache(t *testing.T) {
 	hostInfo, err := host_info_util.NewHostInfoBuilder().SetHost("database-test-name.cluster-XYZ.us-east-2.rds.amazonaws.com").SetPort(1234).Build()
 	assert.Nil(t, err)
-	mockConnFunc := func() (driver.Conn, error) { return &MockConn{throwError: true}, nil }
+	mockConnFunc := func(props map[string]string) (driver.Conn, error) { return &MockConn{throwError: true}, nil }
 	secretIds := [4]string{"id1", "id1", "id3", "id4"}
 	region := [4]string{"us-west-2", "us-west-1", "us-west-2", "us-west-2"}
 
@@ -328,7 +356,11 @@ func TestAwsSecretsManagerConnectionPluginLoginError(t *testing.T) {
 	hostInfo, err := host_info_util.NewHostInfoBuilder().SetHost("database-test-name.cluster-XYZ.us-east-2.rds.amazonaws.com").SetPort(1234).Build()
 	assert.Nil(t, err)
 	mockLoginError := &mysql.MySQLError{SQLState: [5]byte(([]byte(mysql_driver.SqlStateAccessError))[:5])}
-	mockConnFunc := func() (driver.Conn, error) { return nil, mockLoginError }
+	var resultProps map[string]string
+	mockConnFunc := func(props map[string]string) (driver.Conn, error) {
+		resultProps = props
+		return nil, mockLoginError
+	}
 
 	props := map[string]string{
 		property_util.SECRETS_MANAGER_REGION.Name:    "us-west-2",
@@ -345,6 +377,6 @@ func TestAwsSecretsManagerConnectionPluginLoginError(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Equal(t, mockLoginError, err)
 	assert.Equal(t, 1, aws_secrets_manager.SecretsCache.Size())
-	assert.Equal(t, "testuser", props[property_util.USER.Name])
-	assert.Equal(t, "testpassword", props[property_util.PASSWORD.Name])
+	assert.Equal(t, "testuser", resultProps[property_util.USER.Name])
+	assert.Equal(t, "testpassword", resultProps[property_util.PASSWORD.Name])
 }

--- a/.test/test/benchmark_plugin.go
+++ b/.test/test/benchmark_plugin.go
@@ -55,7 +55,7 @@ func (b *BenchmarkPlugin) Connect(
 	isInitialConnection bool,
 	connectFunc driver_infrastructure.ConnectFunc) (driver.Conn, error) {
 	b.resources = append(b.resources, "connect")
-	return connectFunc()
+	return connectFunc(props)
 }
 
 func (b *BenchmarkPlugin) ForceConnect(
@@ -64,7 +64,7 @@ func (b *BenchmarkPlugin) ForceConnect(
 	isInitialConnection bool,
 	connectFunc driver_infrastructure.ConnectFunc) (driver.Conn, error) {
 	b.resources = append(b.resources, "forceConnect")
-	return connectFunc()
+	return connectFunc(props)
 }
 
 func (b *BenchmarkPlugin) Execute(

--- a/.test/test/efm_test.go
+++ b/.test/test/efm_test.go
@@ -191,7 +191,7 @@ func TestHostMonitoringPluginConnect(t *testing.T) {
 	assert.Nil(t, err)
 	rdsHostInfo, err := host_info_util.NewHostInfoBuilder().SetHost("instance-a-1.xyz.us-east-2.rds.amazonaws.com").Build()
 	assert.Nil(t, err)
-	connectFunc := func() (driver.Conn, error) {
+	connectFunc := func(props map[string]string) (driver.Conn, error) {
 		return &MockDriverConnection{}, nil
 	}
 

--- a/.test/test/iam_auth_plugin_test.go
+++ b/.test/test/iam_auth_plugin_test.go
@@ -42,7 +42,11 @@ func beforeIamAuthPluginTests(props map[string]string) (driver_infrastructure.Pl
 func TestIamAuthPluginConnect(t *testing.T) {
 	hostInfo, err := host_info_util.NewHostInfoBuilder().SetHost("database-test-name.cluster-XYZ.us-east-2.rds.amazonaws.com").SetPort(1234).Build()
 	assert.Nil(t, err)
-	mockConnFunc := func() (driver.Conn, error) { return &MockConn{throwError: true}, nil }
+	var resultProps map[string]string
+	mockConnFunc := func(props map[string]string) (driver.Conn, error) {
+		resultProps = props
+		return &MockConn{throwError: true}, nil
+	}
 
 	props := map[string]string{
 		property_util.USER.Name:            "someUser",
@@ -57,7 +61,7 @@ func TestIamAuthPluginConnect(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t,
 		mockIamTokenUtility.(*MockIamTokenUtility).GetMockTokenValue(),
-		property_util.GetVerifiedWrapperPropertyValue[string](props, property_util.PASSWORD))
+		property_util.GetVerifiedWrapperPropertyValue[string](resultProps, property_util.PASSWORD))
 	assert.Equal(t, "someUser", mockIamTokenUtility.(*MockIamTokenUtility).CapturedUsername)
 	assert.Equal(t, "database-test-name.cluster-XYZ.us-east-2.rds.amazonaws.com", mockIamTokenUtility.(*MockIamTokenUtility).CapturedHost)
 	assert.Equal(t, 1234, mockIamTokenUtility.(*MockIamTokenUtility).CapturedPort)
@@ -67,7 +71,11 @@ func TestIamAuthPluginConnect(t *testing.T) {
 func TestIamAuthPluginConnectWithIamProps(t *testing.T) {
 	hostInfo, err := host_info_util.NewHostInfoBuilder().SetHost("database-test-name.cluster-XYZ.us-east-2.rds.amazonaws.com").SetPort(1234).Build()
 	assert.Nil(t, err)
-	mockConnFunc := func() (driver.Conn, error) { return &MockConn{throwError: true}, nil }
+	var resultProps map[string]string
+	mockConnFunc := func(props map[string]string) (driver.Conn, error) {
+		resultProps = props
+		return &MockConn{throwError: true}, nil
+	}
 
 	props := map[string]string{
 		property_util.USER.Name:             "someUser",
@@ -85,7 +93,7 @@ func TestIamAuthPluginConnectWithIamProps(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t,
 		mockIamTokenUtility.(*MockIamTokenUtility).GetMockTokenValue(),
-		property_util.GetVerifiedWrapperPropertyValue[string](props, property_util.PASSWORD))
+		property_util.GetVerifiedWrapperPropertyValue[string](resultProps, property_util.PASSWORD))
 	assert.Equal(t, "someUser", mockIamTokenUtility.(*MockIamTokenUtility).CapturedUsername)
 	assert.Equal(t, "someIamHost", mockIamTokenUtility.(*MockIamTokenUtility).CapturedHost)
 	assert.Equal(t, 9999, mockIamTokenUtility.(*MockIamTokenUtility).CapturedPort)
@@ -95,7 +103,7 @@ func TestIamAuthPluginConnectWithIamProps(t *testing.T) {
 func TestIamAuthPluginConnectInvalidRegionError(t *testing.T) {
 	hostInfo, err := host_info_util.NewHostInfoBuilder().SetHost("mydatabasewithnoregion.com").SetPort(1234).Build()
 	assert.Nil(t, err)
-	mockConnFunc := func() (driver.Conn, error) { return &MockConn{throwError: true}, nil }
+	mockConnFunc := func(props map[string]string) (driver.Conn, error) { return &MockConn{throwError: true}, nil }
 
 	props := map[string]string{
 		property_util.USER.Name:            "someUser",
@@ -115,7 +123,7 @@ func TestIamAuthPluginConnectInvalidRegionError(t *testing.T) {
 func TestIamAuthPluginConnectPopulatesEmptyTokenCache(t *testing.T) {
 	hostInfo, err := host_info_util.NewHostInfoBuilder().SetHost("database-test-name.cluster-XYZ.us-east-2.rds.amazonaws.com").SetPort(1234).Build()
 	assert.Nil(t, err)
-	mockConnFunc := func() (driver.Conn, error) { return &MockConn{throwError: true}, nil }
+	mockConnFunc := func(props map[string]string) (driver.Conn, error) { return &MockConn{throwError: true}, nil }
 
 	props := map[string]string{
 		property_util.USER.Name:            "someUser",
@@ -136,7 +144,7 @@ func TestIamAuthPluginConnectPopulatesEmptyTokenCache(t *testing.T) {
 func TestIamAuthPluginConnectUsesCachedToken(t *testing.T) {
 	hostInfo, err := host_info_util.NewHostInfoBuilder().SetHost("database-test-name.cluster-XYZ.us-east-2.rds.amazonaws.com").SetPort(1234).Build()
 	assert.Nil(t, err)
-	mockConnFunc := func() (driver.Conn, error) { return &MockConn{throwError: true}, nil }
+	mockConnFunc := func(props map[string]string) (driver.Conn, error) { return &MockConn{throwError: true}, nil }
 
 	props := map[string]string{
 		property_util.USER.Name:             "someUser",
@@ -170,7 +178,11 @@ func TestIamAuthPluginConnectUsesCachedToken(t *testing.T) {
 func TestIamAuthPluginConnectCacheExpiredToken(t *testing.T) {
 	hostInfo, err := host_info_util.NewHostInfoBuilder().SetHost("database-test-name.cluster-XYZ.us-east-2.rds.amazonaws.com").SetPort(1234).Build()
 	assert.Nil(t, err)
-	mockConnFunc := func() (driver.Conn, error) { return &MockConn{throwError: true}, nil }
+	var resultProps map[string]string
+	mockConnFunc := func(props map[string]string) (driver.Conn, error) {
+		resultProps = props
+		return &MockConn{throwError: true}, nil
+	}
 
 	props := map[string]string{
 		property_util.USER.Name:             "someUser",
@@ -185,9 +197,9 @@ func TestIamAuthPluginConnectCacheExpiredToken(t *testing.T) {
 	expiredCacheExpirationDuration := -(time.Duration(180) * time.Second)
 	cachedToken := "someCachedToken"
 	cacheKey := auth_helpers.GetCacheKey(
-		property_util.GetVerifiedWrapperPropertyValue[string](props, property_util.USER),
-		property_util.GetVerifiedWrapperPropertyValue[string](props, property_util.IAM_HOST),
-		property_util.GetVerifiedWrapperPropertyValue[int](props, property_util.IAM_DEFAULT_PORT),
+		property_util.GetVerifiedWrapperPropertyValue[string](resultProps, property_util.USER),
+		property_util.GetVerifiedWrapperPropertyValue[string](resultProps, property_util.IAM_HOST),
+		property_util.GetVerifiedWrapperPropertyValue[int](resultProps, property_util.IAM_DEFAULT_PORT),
 		region_util.US_EAST_1,
 	)
 
@@ -201,7 +213,7 @@ func TestIamAuthPluginConnectCacheExpiredToken(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t,
 		mockIamTokenUtility.(*MockIamTokenUtility).GetMockTokenValue(),
-		property_util.GetVerifiedWrapperPropertyValue[string](props, property_util.PASSWORD))
+		property_util.GetVerifiedWrapperPropertyValue[string](resultProps, property_util.PASSWORD))
 	assert.Equal(t, "someUser", mockIamTokenUtility.(*MockIamTokenUtility).CapturedUsername)
 	assert.Equal(t, "someIamHost", mockIamTokenUtility.(*MockIamTokenUtility).CapturedHost)
 	assert.Equal(t, 9999, mockIamTokenUtility.(*MockIamTokenUtility).CapturedPort)
@@ -213,7 +225,9 @@ func TestIamAuthPluginConnectTtlExpiredCachedToken(t *testing.T) {
 	assert.Nil(t, err)
 	mockLoginError := &mysql.MySQLError{SQLState: [5]byte(([]byte(mysql_driver.SqlStateAccessError))[:5])}
 	mockConnFuncCallCounter := 0
-	mockConnFunc := func() (driver.Conn, error) {
+	var resultProps map[string]string
+	mockConnFunc := func(props map[string]string) (driver.Conn, error) {
+		resultProps = props
 		if mockConnFuncCallCounter == 0 {
 			mockConnFuncCallCounter++
 			return nil, mockLoginError
@@ -252,7 +266,7 @@ func TestIamAuthPluginConnectTtlExpiredCachedToken(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t,
 		mockIamTokenUtility.(*MockIamTokenUtility).GetMockTokenValue(),
-		property_util.GetVerifiedWrapperPropertyValue[string](props, property_util.PASSWORD))
+		property_util.GetVerifiedWrapperPropertyValue[string](resultProps, property_util.PASSWORD))
 	assert.Equal(t, "someUser", mockIamTokenUtility.(*MockIamTokenUtility).CapturedUsername)
 	assert.Equal(t, "someIamHost", mockIamTokenUtility.(*MockIamTokenUtility).CapturedHost)
 	assert.Equal(t, 9999, mockIamTokenUtility.(*MockIamTokenUtility).CapturedPort)
@@ -263,7 +277,11 @@ func TestIamAuthPluginConnectLoginError(t *testing.T) {
 	hostInfo, err := host_info_util.NewHostInfoBuilder().SetHost("database-test-name.cluster-XYZ.us-east-2.rds.amazonaws.com").SetPort(1234).Build()
 	assert.Nil(t, err)
 	mockLoginError := &mysql.MySQLError{SQLState: [5]byte(([]byte(mysql_driver.SqlStateAccessError))[:5])}
-	mockConnFunc := func() (driver.Conn, error) { return nil, mockLoginError }
+	var resultProps map[string]string
+	mockConnFunc := func(props map[string]string) (driver.Conn, error) {
+		resultProps = props
+		return nil, mockLoginError
+	}
 
 	props := map[string]string{
 		property_util.USER.Name:            "someUser",
@@ -280,7 +298,7 @@ func TestIamAuthPluginConnectLoginError(t *testing.T) {
 	assert.Equal(t, mockLoginError, err)
 	assert.Equal(t,
 		mockIamTokenUtility.(*MockIamTokenUtility).GetMockTokenValue(),
-		property_util.GetVerifiedWrapperPropertyValue[string](props, property_util.PASSWORD))
+		property_util.GetVerifiedWrapperPropertyValue[string](resultProps, property_util.PASSWORD))
 	assert.Equal(t, "someUser", mockIamTokenUtility.(*MockIamTokenUtility).CapturedUsername)
 	assert.Equal(t, "database-test-name.cluster-XYZ.us-east-2.rds.amazonaws.com", mockIamTokenUtility.(*MockIamTokenUtility).CapturedHost)
 	assert.Equal(t, 1234, mockIamTokenUtility.(*MockIamTokenUtility).CapturedPort)

--- a/.test/test/limitless_plugin_test.go
+++ b/.test/test/limitless_plugin_test.go
@@ -92,7 +92,7 @@ func TestLimitlessPluginConnectGivenDialectRecoverySuccess(t *testing.T) {
 	mockConn := &MockConn{}
 	mockLimitlessRouterService := &MockLimitlessRouterService{}
 
-	mockConnFunc := func() (driver.Conn, error) {
+	mockConnFunc := func(props map[string]string) (driver.Conn, error) {
 		pluginServiceImpl.SetDialect(&driver_infrastructure.AuroraPgDatabaseDialect{})
 		return mockConn, nil
 	}
@@ -126,7 +126,7 @@ func TestLimitlessPluginConnectGivenDialectRecoveryFailure(t *testing.T) {
 	mockConn := &MockConn{}
 	mockLimitlessRouterService := &MockLimitlessRouterService{}
 
-	mockConnFunc := func() (driver.Conn, error) {
+	mockConnFunc := func(props map[string]string) (driver.Conn, error) {
 		return mockConn, nil
 	}
 
@@ -296,7 +296,7 @@ func TestLimitlessMonitorServiceEstablishConnection(t *testing.T) {
 	pluginServiceImpl, _ := plugin_helpers.NewPluginServiceImpl(mockPluginManager, mysql_driver.NewMySQLDriverDialect(), props, pgLimitlessTestDsn)
 	pluginServiceImpl.SetHostListProvider(mockHostListProviderService)
 
-	limitlessRouterService := limitless.NewLimitlessRouterServiceImplInternal(pluginServiceImpl, nil)
+	limitlessRouterService := limitless.NewLimitlessRouterServiceImplInternal(pluginServiceImpl, nil, props)
 
 	cachedRouter0, _ := host_info_util.NewHostInfoBuilder().SetHost("host0").SetWeight(10).Build()
 	cachedRouter1, _ := host_info_util.NewHostInfoBuilder().SetHost("host1").SetWeight(9).Build()
@@ -307,7 +307,7 @@ func TestLimitlessMonitorServiceEstablishConnection(t *testing.T) {
 
 	host, _ := host_info_util.NewHostInfoBuilder().SetHost("host1").SetWeight(9).Build()
 	mockConn := &MockConn{}
-	mockConnFunc := func() (driver.Conn, error) {
+	mockConnFunc := func(props map[string]string) (driver.Conn, error) {
 		return mockConn, nil
 	}
 	context := limitless.NewConnectionContext(*host, props, nil, mockConnFunc, nil)
@@ -340,13 +340,13 @@ func TestLimitlessMonitorServiceEstablishConnect_GivenEmptyCacheAndNoWaitForRout
 	pluginServiceImpl, _ := plugin_helpers.NewPluginServiceImpl(mockPluginManager, mysql_driver.NewMySQLDriverDialect(), props, pgLimitlessTestDsn)
 	pluginServiceImpl.SetHostListProvider(mockHostListProviderService)
 
-	limitlessRouterService := limitless.NewLimitlessRouterServiceImplInternal(pluginServiceImpl, nil)
+	limitlessRouterService := limitless.NewLimitlessRouterServiceImplInternal(pluginServiceImpl, nil, props)
 
 	defer limitless.LIMITLESS_ROUTER_CACHE.Clear()
 
 	host, _ := host_info_util.NewHostInfoBuilder().SetHost("host1").SetWeight(9).Build()
 	mockConn := &MockConn{}
-	mockConnFunc := func() (driver.Conn, error) {
+	mockConnFunc := func(props map[string]string) (driver.Conn, error) {
 		return mockConn, nil
 	}
 	context := limitless.NewConnectionContext(*host, props, nil, mockConnFunc, nil)
@@ -382,13 +382,13 @@ func TestLimitlessMonitorServiceEstablishConnect_MaxRetries(t *testing.T) {
 
 	mockLimitlessQueryHelper := &MockLimitlessQueryHelper{}
 
-	limitlessRouterService := limitless.NewLimitlessRouterServiceImplInternal(pluginServiceImpl, mockLimitlessQueryHelper)
+	limitlessRouterService := limitless.NewLimitlessRouterServiceImplInternal(pluginServiceImpl, mockLimitlessQueryHelper, props)
 
 	defer limitless.LIMITLESS_ROUTER_CACHE.Clear()
 
 	host, _ := host_info_util.NewHostInfoBuilder().SetHost("host1").SetWeight(9).Build()
 	mockConn := &MockConn{}
-	mockConnFunc := func() (driver.Conn, error) {
+	mockConnFunc := func(props map[string]string) (driver.Conn, error) {
 		return mockConn, nil
 	}
 	context := limitless.NewConnectionContext(*host, props, nil, mockConnFunc, nil)

--- a/.test/test/mock_implementations.go
+++ b/.test/test/mock_implementations.go
@@ -97,7 +97,7 @@ func (t TestPlugin) Connect(
 		*t.calls = append(*t.calls, fmt.Sprintf("%s%v:connection", reflect.TypeOf(t), t.id))
 		return t.connection, nil
 	}
-	conn, err := connectFunc()
+	conn, err := connectFunc(properties)
 	if !t.isBefore && t.error != nil {
 		return nil, t.error
 	}
@@ -115,7 +115,7 @@ func (t TestPlugin) ForceConnect(
 		*t.calls = append(*t.calls, fmt.Sprintf("%s%v:forced connection", reflect.TypeOf(t), t.id))
 		return t.connection, nil
 	}
-	conn, err := connectFunc()
+	conn, err := connectFunc(properties)
 	*t.calls = append(*t.calls, fmt.Sprintf("%s%v:after forceConnect", reflect.TypeOf(t), t.id))
 	return conn, err
 }

--- a/.test/test_framework/host/src/test/java/integration/host/TestEnvironmentConfig.java
+++ b/.test/test_framework/host/src/test/java/integration/host/TestEnvironmentConfig.java
@@ -714,7 +714,6 @@ public class TestEnvironmentConfig implements AutoCloseable {
         .withEnv("AWS_SESSION_TOKEN", env.awsSessionToken)
         .withEnv("AWS_REGION", otlpRegion);
 
-    System.out.println("MAKING OTEL CONTAINER WITH NAME: " + TELEMETRY_OTLP_CONTAINER_NAME);
     env.info.setOtelTracesTelemetryInfo(new TestTelemetryInfo(TELEMETRY_OTLP_CONTAINER_NAME, 4317));
     env.info.setMetricsTelemetryInfo(new TestTelemetryInfo(TELEMETRY_OTLP_CONTAINER_NAME, 4317));
 

--- a/awssql/driver_infrastructure/cluster_topology_monitor.go
+++ b/awssql/driver_infrastructure/cluster_topology_monitor.go
@@ -236,7 +236,7 @@ func (c *ClusterTopologyMonitorImpl) openAnyConnectionAndUpdateTopology() ([]*ho
 
 	if c.loadConn(c.monitoringConn) == nil {
 		// Open a new connection.
-		conn, err := c.pluginService.ForceConnect(c.initialHostInfo, c.monitoringProps)
+		conn, err := c.pluginService.ForceConnect(c.initialHostInfo, utils.CreateMapCopy(c.monitoringProps))
 		if err != nil {
 			// Can't connect.
 			return nil, err
@@ -542,7 +542,7 @@ func (h *HostMonitoringRoutine) run() {
 
 	for !h.monitor.hostRoutinesStop.Load() {
 		if conn == nil {
-			conn, err = h.monitor.pluginService.ForceConnect(h.hostInfo, h.monitor.monitoringProps)
+			conn, err = h.monitor.pluginService.ForceConnect(h.hostInfo, utils.CreateMapCopy(h.monitor.monitoringProps))
 			if err != nil {
 				// Connect issues.
 				h.monitor.pluginService.SetAvailability(h.hostInfo.AllAliases, host_info_util.UNAVAILABLE)

--- a/awssql/driver_infrastructure/plugin_helpers.go
+++ b/awssql/driver_infrastructure/plugin_helpers.go
@@ -23,10 +23,10 @@ import (
 	"github.com/aws/aws-advanced-go-wrapper/awssql/utils/telemetry"
 )
 
-type ConnectFunc func() (driver.Conn, error)
+type ConnectFunc func(props map[string]string) (driver.Conn, error)
 type ExecuteFunc func() (any, any, bool, error)
 type PluginExecFunc func(plugin ConnectionPlugin, targetFunc func() (any, any, bool, error)) (any, any, bool, error)
-type PluginConnectFunc func(plugin ConnectionPlugin, targetFunc func() (driver.Conn, error)) (driver.Conn, error)
+type PluginConnectFunc func(plugin ConnectionPlugin, props map[string]string, targetFunc func(props map[string]string) (driver.Conn, error)) (driver.Conn, error)
 
 type HostListProviderService interface {
 	IsStaticHostListProvider() bool

--- a/awssql/plugins/base_connection_plugin.go
+++ b/awssql/plugins/base_connection_plugin.go
@@ -44,7 +44,7 @@ func (b BaseConnectionPlugin) Connect(
 	props map[string]string,
 	isInitialConnection bool,
 	connectFunc driver_infrastructure.ConnectFunc) (driver.Conn, error) {
-	return connectFunc()
+	return connectFunc(props)
 }
 
 func (b BaseConnectionPlugin) ForceConnect(
@@ -52,7 +52,7 @@ func (b BaseConnectionPlugin) ForceConnect(
 	props map[string]string,
 	isInitialConnection bool,
 	connectFunc driver_infrastructure.ConnectFunc) (driver.Conn, error) {
-	return connectFunc()
+	return connectFunc(props)
 }
 
 func (b BaseConnectionPlugin) AcceptsStrategy(strategy string) bool {

--- a/awssql/plugins/efm/host_monitoring_plugin.go
+++ b/awssql/plugins/efm/host_monitoring_plugin.go
@@ -70,7 +70,7 @@ func (b *HostMonitorConnectionPlugin) Connect(
 	props map[string]string,
 	isInitialConnection bool,
 	connectFunc driver_infrastructure.ConnectFunc) (driver.Conn, error) {
-	conn, err := connectFunc()
+	conn, err := connectFunc(props)
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +110,7 @@ func (b *HostMonitorConnectionPlugin) Execute(
 		return nil, nil, false, err
 	}
 
-	// Sets up a MonitorConnectionState that is active for the duration of executeFÏreadounc.
+	// Sets up a MonitorConnectionState that is active for the duration of executeFunc.
 	// If there are any issues setting up the monitor/state, the error is passed on in wrappedErr.
 	var monitorState *MonitorConnectionState
 	monitoringHostInfo, err := b.getMonitoringHostInfo()

--- a/awssql/plugins/efm/monitor.go
+++ b/awssql/plugins/efm/monitor.go
@@ -251,7 +251,7 @@ func (m *MonitorImpl) CheckConnectionStatus() bool {
 	if m.MonitoringConn == nil || m.pluginService.GetTargetDriverDialect().IsClosed(m.MonitoringConn) {
 		// Open a new connection.
 		slog.Debug(error_util.GetMessage("MonitorImpl.openingMonitoringConnection", m.hostInfo.Host))
-		newMonitoringConn, err := m.pluginService.ForceConnect(m.hostInfo, m.monitoringProps)
+		newMonitoringConn, err := m.pluginService.ForceConnect(m.hostInfo, utils.CreateMapCopy(m.monitoringProps))
 		if err != nil || newMonitoringConn == nil {
 			return false
 		}

--- a/awssql/plugins/failover_plugin.go
+++ b/awssql/plugins/failover_plugin.go
@@ -605,8 +605,8 @@ func (p *FailoverPlugin) shouldErrorTriggerConnectionSwitch(err error) bool {
 }
 
 func (p *FailoverPlugin) createConnectionForHost(hostInfo *host_info_util.HostInfo) (driver.Conn, error) {
-	copyProps := utils.CreateMapCopy(p.props)
-	copyProps[property_util.HOST.Name] = hostInfo.Host
-	copyProps[property_util.INTERNAL_CONNECT_PROPERTY_NAME] = "true"
-	return p.pluginService.Connect(hostInfo, copyProps)
+	propsCopy := utils.CreateMapCopy(p.props)
+	property_util.HOST.Set(propsCopy, hostInfo.Host)
+	propsCopy[property_util.INTERNAL_CONNECT_PROPERTY_NAME] = "true"
+	return p.pluginService.Connect(hostInfo, propsCopy)
 }

--- a/awssql/plugins/limitless/limitless_plugin.go
+++ b/awssql/plugins/limitless/limitless_plugin.go
@@ -78,7 +78,7 @@ func (plugin *LimitlessPlugin) Connect(
 	dialect := plugin.pluginService.GetDialect()
 	if !IsDialectLimitless(dialect) {
 		var err error
-		conn, err = connectFunc()
+		conn, err = connectFunc(props)
 		if err != nil {
 			return nil, err
 		}
@@ -115,6 +115,6 @@ func (plugin *LimitlessPlugin) Connect(
 
 func (plugin *LimitlessPlugin) initLimitlessRouterService() {
 	if plugin.routerService == nil {
-		plugin.routerService = NewLimitlessRouterServiceImpl(plugin.pluginService)
+		plugin.routerService = NewLimitlessRouterServiceImpl(plugin.pluginService, plugin.props)
 	}
 }

--- a/awssql/plugins/limitless/limitless_router_monitor.go
+++ b/awssql/plugins/limitless/limitless_router_monitor.go
@@ -62,7 +62,7 @@ func NewLimitlessRouterMonitorImpl(
 		props:          maps.Clone(props),
 	}
 
-	monitor.props[property_util.LIMITLESS_WAIT_FOR_ROUTER_INFO.Name] = "false"
+	property_util.LIMITLESS_WAIT_FOR_ROUTER_INFO.Set(monitor.props, "false")
 	go monitor.run()
 
 	return monitor
@@ -142,7 +142,7 @@ func (monitor *LimitlessRouterMonitorImpl) openConnection() error {
 	if monitor.monitoringConn == nil {
 		// open a new connection
 		slog.Info(error_util.GetMessage("LimitlessRouterMonitorImpl.openingConnection", monitor.hostInfo.Host))
-		newConn, err := monitor.pluginService.ForceConnect(monitor.hostInfo, monitor.props)
+		newConn, err := monitor.pluginService.ForceConnect(monitor.hostInfo, utils.CreateMapCopy(monitor.props))
 		if err != nil {
 			if newConn != nil {
 				_ = newConn.Close()

--- a/awssql/plugins/stale_dns_helper.go
+++ b/awssql/plugins/stale_dns_helper.go
@@ -50,7 +50,7 @@ func (s *StaleDnsHelper) GetVerifiedConnection(
 	hostListProviderService driver_infrastructure.HostListProviderService,
 	props map[string]string,
 	connectFunc driver_infrastructure.ConnectFunc) (driver.Conn, error) {
-	conn, err := connectFunc()
+	conn, err := connectFunc(props)
 
 	if !utils.IsWriterClusterDns(host) {
 		return conn, err
@@ -126,7 +126,7 @@ func (s *StaleDnsHelper) GetVerifiedConnection(
 
 		s.staleDnsCounter.Inc(s.pluginService.GetTelemetryContext())
 
-		writerConn, connectErr := s.pluginService.Connect(s.writerHostInfo, props)
+		writerConn, connectErr := s.pluginService.Connect(s.writerHostInfo, utils.CreateMapCopy(props))
 		if connectErr != nil {
 			return nil, connectErr
 		}


### PR DESCRIPTION
### Summary

fix: concurrent map access

### Description

- adds properties map to connect pipeline so plugins can pass changed properties to each other
- creates copies of properties when calling pluginService.Connect or pluginService.ForceConnect
- adds integration tests for iam and failover, and secrets manager and failover

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
