### PR TITLE
fix: secrets manager validation

### DIFF
--- a/aws-secrets-manager/aws_secrets_manager_connection_util.go
+++ b/aws-secrets-manager/aws_secrets_manager_connection_util.go
@@ -21,11 +21,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
+
 	"github.com/aws/aws-advanced-go-wrapper/awssql/error_util"
 	"github.com/aws/aws-advanced-go-wrapper/awssql/host_info_util"
 	"github.com/aws/aws-advanced-go-wrapper/awssql/property_util"
 	"github.com/aws/aws-advanced-go-wrapper/awssql/region_util"
-	"log/slog"
 
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 )
@@ -85,15 +86,19 @@ func getRdsSecretFromAwsSecretsManager(
 }
 
 func GetAwsSecretsManagerRegion(regionStr string, secretId string) (region_util.Region, error) {
-	region := region_util.GetRegionFromRegionString(regionStr)
-	if region != "" {
+	if regionStr != "" {
+		region := region_util.GetRegionFromRegionString(regionStr)
+
+		if region == "" {
+			return region, errors.New(error_util.GetMessage("AwsSecretsManagerConnectionPlugin.invalidRegion", regionStr))
+		}
+
 		return region, nil
 	}
 
-	region = region_util.GetRegionFromArn(secretId)
+	region := region_util.GetRegionFromArn(secretId)
 	if region == "" {
 		return region, errors.New(error_util.GetMessage("AwsSecretsManagerConnectionPlugin.unableToDetermineRegion", property_util.SECRETS_MANAGER_REGION.Name))
 	}
-
 	return region, nil
 }

--- a/awssql/resources/en.json
+++ b/awssql/resources/en.json
@@ -9,6 +9,8 @@
 	"AwsClientHelper.errorGettingClientConfig": "Error occurred while loading configuration for aws client: '%v'.",
 	"AwsSecretsManagerConnectionPlugin.endpointOverrideMisconfigured" : "The provided endpoint is invalid and could not be used to create a URI: '%v'.",
 	"AwsSecretsManagerConnectionPlugin.failedToFetchDbCredentials" : "Was not able to either fetch or read the database credentials from AWS Secrets Manager. Ensure the correct secretId and region properties have been provided.",
+	"AwsSecretsManagerConnectionPlugin.invalidRegion": "Invalid AWS Secrets Manager Region was given: '%s'.",
+	"AwsSecretsManagerConnectionPlugin.secretIdMissing": "A secret id or a secret arn must be provided in the '%v' property.",
 	"AwsSecretsManagerConnectionPlugin.unableToCreateAwsSecretsManagerClient": "Error occurred while initializing the AwsSecretsManager client",
 	"AwsSecretsManagerConnectionPlugin.unableToDetermineRegion": "Unable to determine connection region. If you are not providing a secret ARN, please set the '%v' property.",
 	"AwsSecretsManagerConnectionPlugin.unableToGetSecretValue" : "Error occurred while getting secret value from AwsSecretsManager: '%v'. ",


### PR DESCRIPTION
### Summary
Added the following validations in secrets manager plugin: 
- Validates that secret id is present
- Validates that region is a valid AWS region


### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
