### PR TITLE
fix: add limitlessUseShardGroupUrl property

### DIFF
--- a/.test/test/connection_plugin_chain_builder_test.go
+++ b/.test/test/connection_plugin_chain_builder_test.go
@@ -110,7 +110,7 @@ func TestSortAllPlugins(t *testing.T) {
 	mockPluginManager.EXPECT().GetConnectionProviderManager().Return(driver_infrastructure.ConnectionProviderManager{}).AnyTimes()
 
 	builder := &awsDriver.ConnectionPluginChainBuilder{}
-	props := map[string]string{property_util.PLUGINS.Name: "iam,executionTime,limitless,efm,failover"}
+	props := map[string]string{property_util.PLUGINS.Name: "iam,executionTime,limitless,efm,failover", property_util.LIMITLESS_USE_SHARD_GROUP_URL.Name: "false"}
 	availablePlugins := map[string]driver_infrastructure.ConnectionPluginFactory{
 		"failover":      plugins.NewFailoverPluginFactory(),
 		"efm":           efm.NewHostMonitoringPluginFactory(),

--- a/awssql/property_util/aws_wrapper_property.go
+++ b/awssql/property_util/aws_wrapper_property.go
@@ -565,6 +565,13 @@ var LIMITLESS_ROUTER_QUERY_TIMEOUT_MS = AwsWrapperProperty{
 	wrapperPropertyType: WRAPPER_TYPE_INT,
 }
 
+var LIMITLESS_USE_SHARD_GROUP_URL = AwsWrapperProperty{
+	Name:                "limitlessUseShardGroupUrl",
+	description:         "When this parameter is set to true, provided host endpoints must be database shard group URLs. Set to false to disable this check.",
+	defaultValue:        "true",
+	wrapperPropertyType: WRAPPER_TYPE_BOOL,
+}
+
 func RemoveInternalAwsWrapperProperties(props map[string]string) map[string]string {
 	copyProps := map[string]string{}
 

--- a/awssql/resources/en.json
+++ b/awssql/resources/en.json
@@ -110,6 +110,7 @@
 	"IamAuthPlugin.errorGettingAwsCredentialsProvider": "Error occurred while getting aws.CredentialsProvider: '%v'.",
 	"IamAuthPlugin.unableToDetermineRegion": "Unable to determine connection region. If you are using a non-standard RDS URL, please set the '%v' property.",
 	"IamAuthPlugin.useCachedToken": "Using cached authentication token.",
+	"LimitlessPlugin.expectedShardGroupUrl": "The provided host was not a shard group URL: '%s'.",
 	"LimitlessPlugin.failedToConnectToHost": "Limitless Plugin failed to connect to host %v.",
 	"LimitlessPlugin.invalidDatabaseUrl": "Invalid Limitless Database URL '%v'. Please use a valid Limitless DB Shard Group endpoint URL.",
 	"LimitlessPlugin.unsupportedDialectOrDatabase": "Unsupported dialect '%T' encountered. Please ensure connection parameters are correct, and refer to the documentation to ensure that the connecting database is compatible with the Limitless Connection Plugin.",


### PR DESCRIPTION
### Summary

<!--- General summary / title -->

### Description

- adds the limitlessUseShardGroupUrl property to validate whether the provided host is a shard group URL

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
