### PR TITLE
fix: remove expired cache item on compute if absent

### DIFF
--- a/awssql/plugins/limitless/limitless_router_service.go
+++ b/awssql/plugins/limitless/limitless_router_service.go
@@ -59,6 +59,7 @@ func NewLimitlessRouterServiceImplInternal(
 		LIMITLESS_ROUTER_MONITOR_CACHE = utils.NewSlidingExpirationCache[LimitlessRouterMonitor](
 			"limitless_router_monitors",
 			func(monitor LimitlessRouterMonitor) bool {
+				slog.Debug(error_util.GetMessage("SlidingExpirationCache.itemDisposal", "limitless router monitor"))
 				monitor.Close()
 				return false
 			},
@@ -71,6 +72,7 @@ func NewLimitlessRouterServiceImplInternal(
 		LIMITLESS_ROUTER_CACHE = utils.NewSlidingExpirationCache[[]*host_info_util.HostInfo](
 			"limitless_routers",
 			func(routers []*host_info_util.HostInfo) bool {
+				slog.Debug(error_util.GetMessage("SlidingExpirationCache.itemDisposal", "limitless router"))
 				return false
 			},
 			func(routers []*host_info_util.HostInfo) bool {

--- a/awssql/resources/en.json
+++ b/awssql/resources/en.json
@@ -174,6 +174,7 @@
 	"RdsHostListProvider.unknownHostRole": "Query to gather host role failed, unable to determine role of current host.",
 	"SamlCredentialsProviderFactory.getSamlAssertionFailed": "Failed to get SAML Assertion due to exception: '%s'.",
 	"SlidingExpirationCache.exitingCacheCleanupRoutine": "Sliding expiration cache '%v' cleanup routine has been cancelled.",
+	"SlidingExpirationCache.itemDisposal": "Disposing of %s.",
 	"SlidingExpirationCache.startingCacheCleanupRoutine": "Sliding expiration cache '%v', has been initialized, cleanup routine has started.",
 	"StaleDnsHelper.clusterEndpointDns": "Cluster endpoint resolves to '%s'.",
 	"StaleDnsHelper.staleDnsDetected": "Stale DNS data detected. Opening a connection to '%s'.",


### PR DESCRIPTION
### Summary

<!--- General summary / title -->

### Description

- adds logs on limitless router and limitless router monitor disposal
- calls remove() on expired sliding expiration cache items on computeIfAbsent()

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
