### PR TITLE
fix: mysql dsn parsing when no user/password

### DIFF
--- a/.test/test/dsn_parser_test.go
+++ b/.test/test/dsn_parser_test.go
@@ -327,9 +327,27 @@ func TestParseDsnMySqlWithoutParams(t *testing.T) {
 		t.Errorf(`Unexpected error when calling ParseDsn: %s, Error: %q`, dsn, err)
 	}
 
+	assert.Equal(t, "tcp", props[property_util.NET.Name])
 	assert.Equal(t, "mysql", props[property_util.DRIVER_PROTOCOL.Name])
 	assert.Equal(t, "someUser", props[property_util.USER.Name])
 	assert.Equal(t, "somePassword", props[property_util.PASSWORD.Name])
+	assert.Equal(t, "mydatabase.com", props[property_util.HOST.Name])
+	assert.Equal(t, "3306", props[property_util.PORT.Name])
+	assert.Equal(t, "myDatabase", props[property_util.DATABASE.Name])
+}
+
+func TestParseDsnMySqlNoUserNoPassword(t *testing.T) {
+	dsn := "tcp(mydatabase.com:3306)/myDatabase"
+	props, err := utils.ParseDsn(dsn)
+
+	if err != nil {
+		t.Errorf(`Unexpected error when calling ParseDsn: %s, Error: %q`, dsn, err)
+	}
+
+	assert.Equal(t, "tcp", props[property_util.NET.Name])
+	assert.Equal(t, "mysql", props[property_util.DRIVER_PROTOCOL.Name])
+	assert.Equal(t, "", props[property_util.USER.Name])
+	assert.Equal(t, "", props[property_util.PASSWORD.Name])
 	assert.Equal(t, "mydatabase.com", props[property_util.HOST.Name])
 	assert.Equal(t, "3306", props[property_util.PORT.Name])
 	assert.Equal(t, "myDatabase", props[property_util.DATABASE.Name])

--- a/awssql/utils/dsn_parser.go
+++ b/awssql/utils/dsn_parser.go
@@ -380,7 +380,9 @@ func parseMySqlDsn(dsn string) (properties map[string]string, err error) {
 
 	// [username[:password]@][protocol[(address)]]
 	lastAtIndex := strings.LastIndex(dsn[:lastSlashIndex], "@")
+	netPropStart := 0
 	if lastAtIndex != -1 {
+		netPropStart = lastAtIndex + 1
 		colonIndex := strings.Index(dsn[:lastAtIndex], ":")
 		if colonIndex == -1 {
 			properties[property_util.USER.Name] = dsn[:lastAtIndex]
@@ -388,14 +390,16 @@ func parseMySqlDsn(dsn string) (properties map[string]string, err error) {
 			properties[property_util.USER.Name] = dsn[:colonIndex]
 			properties[property_util.PASSWORD.Name] = dsn[colonIndex+1 : lastAtIndex]
 		}
+	} else {
+		lastAtIndex = 0
 	}
 
 	// [protocol[(address)]]
 	openParenIndex := strings.Index(dsn[lastAtIndex:lastSlashIndex], "(") + lastAtIndex
 	if openParenIndex == -1 {
-		properties[NET_PROP_KEY] = dsn[lastAtIndex+1 : lastSlashIndex]
+		properties[NET_PROP_KEY] = dsn[netPropStart:lastSlashIndex]
 	} else {
-		properties[NET_PROP_KEY] = dsn[lastAtIndex+1 : openParenIndex]
+		properties[NET_PROP_KEY] = dsn[netPropStart:openParenIndex]
 
 		closeParenIndex := strings.LastIndex(dsn[lastAtIndex:lastSlashIndex], ")") + lastAtIndex
 		if closeParenIndex == -1 {


### PR DESCRIPTION
### Summary

Allow mysql DSNs without using a username or password. 

### Description

- Update parsing logic to not require an @ symbol in the mysql dsn
- Currently throws a `panic: runtime error: slice bounds out of range [-1:]` if no user/password is provided

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
