### PR TITLE
feat: connect time plugin

### DIFF
--- a/.test/test/connect_time_plugin_test.go
+++ b/.test/test/connect_time_plugin_test.go
@@ -1,0 +1,123 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+package test
+
+import (
+	"database/sql/driver"
+	"testing"
+	"time"
+
+	mock_driver_infrastructure "github.com/aws/aws-advanced-go-wrapper/.test/test/mocks/awssql/driver_infrastructure"
+	"github.com/aws/aws-advanced-go-wrapper/awssql/plugin_helpers"
+	"github.com/aws/aws-advanced-go-wrapper/awssql/plugins"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConnectTimeFactoryReturnsConnectTimePlugin(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockService := mock_driver_infrastructure.NewMockPluginService(ctrl)
+
+	factory := plugins.NewConnectTimePluginFactory()
+	plugin, err := factory.GetInstance(mockService, map[string]string{})
+	assert.NoError(t, err)
+
+	_, ok := plugin.(*plugins.ConnectTimePlugin)
+	assert.True(t, ok)
+}
+
+func TestConnectTimePlugin_ConnectTracksTime(t *testing.T) {
+	plugin := &plugins.ConnectTimePlugin{}
+
+	connected := false
+	mockConnectFunc := func(props map[string]string) (driver.Conn, error) {
+		time.Sleep(10 * time.Millisecond)
+		connected = true
+		return nil, nil
+	}
+
+	conn, err := plugin.Connect(nil, map[string]string{}, true, mockConnectFunc)
+
+	assert.True(t, connected)
+	assert.Nil(t, conn)
+	assert.NoError(t, err)
+
+	connectTime := plugin.GetTotalConnectTime()
+	assert.Greater(t, connectTime, int64(0))
+}
+
+func TestConnectTimePlugin_ForceConnectTracksTime(t *testing.T) {
+	plugin := &plugins.ConnectTimePlugin{}
+
+	connected := false
+	mockForceConnectFunc := func(props map[string]string) (driver.Conn, error) {
+		time.Sleep(10 * time.Millisecond)
+		connected = true
+		return nil, nil
+	}
+
+	conn, err := plugin.ForceConnect(nil, map[string]string{}, true, mockForceConnectFunc)
+
+	assert.True(t, connected)
+	assert.Nil(t, conn)
+	assert.NoError(t, err)
+
+	connectTime := plugin.GetTotalConnectTime()
+	assert.Greater(t, connectTime, int64(0))
+}
+
+func TestConnectTimePlugin_ResetConnectTime(t *testing.T) {
+	plugin := &plugins.ConnectTimePlugin{}
+	mockConnectFunc := func(props map[string]string) (driver.Conn, error) {
+		time.Sleep(5 * time.Millisecond)
+		return nil, nil
+	}
+
+	_, err := plugin.Connect(nil, map[string]string{}, true, mockConnectFunc)
+	assert.NoError(t, err)
+	assert.Greater(t, plugin.GetTotalConnectTime(), int64(0))
+
+	plugin.ResetConnectTime()
+	assert.Equal(t, int64(0), plugin.GetTotalConnectTime())
+}
+
+func TestConnectTimePlugin_GetSubscribedMethods(t *testing.T) {
+	plugin := &plugins.ConnectTimePlugin{}
+	methods := plugin.GetSubscribedMethods()
+	assert.Contains(t, methods, plugin_helpers.CONNECT_METHOD)
+	assert.Contains(t, methods, plugin_helpers.FORCE_CONNECT_METHOD)
+}
+
+func TestConnectTimePlugin_AccumulatesTime(t *testing.T) {
+	plugin := &plugins.ConnectTimePlugin{}
+	mockConnectFunc := func(props map[string]string) (driver.Conn, error) {
+		time.Sleep(5 * time.Millisecond)
+		return nil, nil
+	}
+
+	_, err := plugin.Connect(nil, map[string]string{}, true, mockConnectFunc)
+	assert.NoError(t, err)
+	firstTime := plugin.GetTotalConnectTime()
+
+	_, err = plugin.ForceConnect(nil, map[string]string{}, true, mockConnectFunc)
+	assert.NoError(t, err)
+	totalTime := plugin.GetTotalConnectTime()
+
+	assert.Greater(t, totalTime, firstTime)
+}

--- a/.test/test/connect_time_plugin_test.go
+++ b/.test/test/connect_time_plugin_test.go
@@ -102,6 +102,7 @@ func TestConnectTimePlugin_GetSubscribedMethods(t *testing.T) {
 	methods := plugin.GetSubscribedMethods()
 	assert.Contains(t, methods, plugin_helpers.CONNECT_METHOD)
 	assert.Contains(t, methods, plugin_helpers.FORCE_CONNECT_METHOD)
+	assert.Len(t, methods, 2)
 }
 
 func TestConnectTimePlugin_AccumulatesTime(t *testing.T) {

--- a/awssql/driver/connection_plugin_chain_builder.go
+++ b/awssql/driver/connection_plugin_chain_builder.go
@@ -46,6 +46,7 @@ var pluginWeightByCode = map[string]int{
 	driver_infrastructure.ADFS_PLUGIN_CODE:                 1200,
 	driver_infrastructure.OKTA_PLUGIN_CODE:                 1300,
 	driver_infrastructure.EXECUTION_TIME_PLUGIN_CODE:       WEIGHT_RELATIVE_TO_PRIOR_PLUGIN,
+	driver_infrastructure.CONNECT_TIME_PLUGIN_CODE:         WEIGHT_RELATIVE_TO_PRIOR_PLUGIN,
 }
 
 type ConnectionPluginChainBuilder struct {

--- a/awssql/driver/driver.go
+++ b/awssql/driver/driver.go
@@ -42,6 +42,7 @@ var pluginFactoryByCode = map[string]driver_infrastructure.ConnectionPluginFacto
 	driver_infrastructure.EXECUTION_TIME_PLUGIN_CODE:       plugins.NewExecutionTimePluginFactory(),
 	driver_infrastructure.READ_WRITE_SPLITTING_PLUGIN_CODE: read_write_splitting.NewReadWriteSplittingPluginFactory(),
 	driver_infrastructure.BLUE_GREEN_PLUGIN_CODE:           bg.NewBlueGreenPluginFactory(),
+	driver_infrastructure.CONNECT_TIME_PLUGIN_CODE:         plugins.NewConnectTimePluginFactory(),
 }
 
 var underlyingDriverList = map[string]driver.Driver{}

--- a/awssql/driver_infrastructure/fixed_value_types.go
+++ b/awssql/driver_infrastructure/fixed_value_types.go
@@ -27,6 +27,7 @@ const (
 	ADFS_PLUGIN_CODE                 string = "federatedAuth"
 	OKTA_PLUGIN_CODE                 string = "okta"
 	EXECUTION_TIME_PLUGIN_CODE       string = "executionTime"
+	CONNECT_TIME_PLUGIN_CODE         string = "connectTime"
 )
 
 type HostChangeOptions int

--- a/awssql/plugins/connect_time_plugin.go
+++ b/awssql/plugins/connect_time_plugin.go
@@ -43,7 +43,7 @@ func (factory ConnectTimePluginFactory) ClearCaches() {}
 
 type ConnectTimePlugin struct {
 	BaseConnectionPlugin
-	connectTime int64
+	connectTimeNano int64
 }
 
 func NewConnectTimePlugin(pluginService driver_infrastructure.PluginService,
@@ -68,7 +68,7 @@ func (d *ConnectTimePlugin) Connect(
 	conn, err := connectFunc(props)
 	elapsed := time.Since(start)
 
-	d.connectTime += elapsed.Nanoseconds()
+	d.connectTimeNano += elapsed.Nanoseconds()
 	slog.Debug(error_util.GetMessage("ConnectTimePlugin.connectTime", elapsed.Milliseconds()))
 	return conn, err
 }
@@ -82,15 +82,15 @@ func (d *ConnectTimePlugin) ForceConnect(
 	conn, err := forceConnectFunc(props)
 	elapsed := time.Since(start)
 
-	d.connectTime += elapsed.Nanoseconds()
+	d.connectTimeNano += elapsed.Nanoseconds()
 	slog.Debug(error_util.GetMessage("ConnectTimePlugin.forceConnectTime", elapsed.Milliseconds()))
 	return conn, err
 }
 
 func (d *ConnectTimePlugin) ResetConnectTime() {
-	d.connectTime = 0
+	d.connectTimeNano = 0
 }
 
 func (d *ConnectTimePlugin) GetTotalConnectTime() int64 {
-	return d.connectTime
+	return d.connectTimeNano
 }

--- a/awssql/plugins/connect_time_plugin.go
+++ b/awssql/plugins/connect_time_plugin.go
@@ -52,7 +52,7 @@ func NewConnectTimePlugin(pluginService driver_infrastructure.PluginService,
 }
 
 func (d *ConnectTimePlugin) GetPluginCode() string {
-	return driver_infrastructure.EXECUTION_TIME_PLUGIN_CODE
+	return driver_infrastructure.CONNECT_TIME_PLUGIN_CODE
 }
 
 func (d *ConnectTimePlugin) GetSubscribedMethods() []string {

--- a/awssql/plugins/connect_time_plugin.go
+++ b/awssql/plugins/connect_time_plugin.go
@@ -1,0 +1,96 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+package plugins
+
+import (
+	"database/sql/driver"
+	"log/slog"
+	"time"
+
+	"github.com/aws/aws-advanced-go-wrapper/awssql/driver_infrastructure"
+	"github.com/aws/aws-advanced-go-wrapper/awssql/error_util"
+	"github.com/aws/aws-advanced-go-wrapper/awssql/host_info_util"
+	"github.com/aws/aws-advanced-go-wrapper/awssql/plugin_helpers"
+)
+
+type ConnectTimePluginFactory struct{}
+
+func NewConnectTimePluginFactory() driver_infrastructure.ConnectionPluginFactory {
+	return ConnectTimePluginFactory{}
+}
+
+func (factory ConnectTimePluginFactory) GetInstance(pluginService driver_infrastructure.PluginService,
+	props map[string]string,
+) (driver_infrastructure.ConnectionPlugin, error) {
+	return NewConnectTimePlugin(pluginService, props)
+}
+
+func (factory ConnectTimePluginFactory) ClearCaches() {}
+
+type ConnectTimePlugin struct {
+	BaseConnectionPlugin
+	connectTime int64
+}
+
+func NewConnectTimePlugin(pluginService driver_infrastructure.PluginService,
+	props map[string]string) (*ConnectTimePlugin, error) {
+	return &ConnectTimePlugin{}, nil
+}
+
+func (d *ConnectTimePlugin) GetPluginCode() string {
+	return driver_infrastructure.EXECUTION_TIME_PLUGIN_CODE
+}
+
+func (d *ConnectTimePlugin) GetSubscribedMethods() []string {
+	return []string{plugin_helpers.CONNECT_METHOD, plugin_helpers.FORCE_CONNECT_METHOD}
+}
+
+func (d *ConnectTimePlugin) Connect(
+	hostInfo *host_info_util.HostInfo,
+	props map[string]string,
+	isInitialConnection bool,
+	connectFunc driver_infrastructure.ConnectFunc) (driver.Conn, error) {
+	start := time.Now()
+	conn, err := connectFunc(props)
+	elapsed := time.Since(start)
+
+	d.connectTime += elapsed.Nanoseconds()
+	slog.Debug(error_util.GetMessage("ConnectTimePlugin.connectTime", elapsed.Milliseconds()))
+	return conn, err
+}
+
+func (d *ConnectTimePlugin) ForceConnect(
+	hostInfo *host_info_util.HostInfo,
+	props map[string]string,
+	isInitialConnection bool,
+	forceConnectFunc driver_infrastructure.ConnectFunc) (driver.Conn, error) {
+	start := time.Now()
+	conn, err := forceConnectFunc(props)
+	elapsed := time.Since(start)
+
+	d.connectTime += elapsed.Nanoseconds()
+	slog.Debug(error_util.GetMessage("ConnectTimePlugin.forceConnectTime", elapsed.Milliseconds()))
+	return conn, err
+}
+
+func (d *ConnectTimePlugin) ResetConnectTime() {
+	d.connectTime = 0
+}
+
+func (d *ConnectTimePlugin) GetTotalConnectTime() int64 {
+	return d.connectTime
+}

--- a/awssql/resources/en.json
+++ b/awssql/resources/en.json
@@ -79,6 +79,8 @@
   "ClusterTopologyMonitorImpl.topologyNotUpdated": "Topology hasn't been updated after %v ms.",
   "ClusterTopologyMonitorImpl.writerMonitoringConnection": "The monitoring connection is connected to a writer: '%s'.",
   "ClusterTopologyMonitorImpl.writerPickedUpFromHostMonitors": "The writer host detected by the host monitors was picked up by the topology monitor: '%s'.",
+  "ConnectTimePlugin.connectTime": "Connected in '%v' milliseconds.",
+  "ConnectTimePlugin.forceConnectTime": "Force-connected in '%v' milliseconds.",
   "Conn.doesNotImplementRequiredInterface": "The given connection does not implement the required interface '%v'.",
   "Conn.invalidTransactionIsolationLevel": "An invalid transaction isolation level was provided: '%v'.",
   "ConnectionPluginManager.unknownPluginCode": "Unknown plugin code: '%s'. Please ensure all plugin codes are valid and any required plugin modules have been imported.",


### PR DESCRIPTION
### Summary

feat: connect time plugin

### Description

Added connect time plugin that allows users to record the time it takes to connect to the database. 

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
