### PR TITLE
fix: return error if failover is not successful

### DIFF
--- a/awssql/plugins/failover_plugin.go
+++ b/awssql/plugins/failover_plugin.go
@@ -200,6 +200,8 @@ func (p *FailoverPlugin) Connect(
 			err = p.Failover()
 			if errors.Is(err, error_util.FailoverSuccessError) {
 				conn = p.pluginService.GetCurrentConnection()
+			} else {
+				return nil, err
 			}
 		}
 	} else {
@@ -210,6 +212,8 @@ func (p *FailoverPlugin) Connect(
 		err := p.Failover()
 		if errors.Is(err, error_util.FailoverSuccessError) {
 			conn = p.pluginService.GetCurrentConnection()
+		} else {
+			return nil, err
 		}
 	}
 


### PR DESCRIPTION
### Summary

fix: return error if failover is not successful

### Description

Previously, if we don't get a failover success, we would not return the underlying error. This commit fixes that and returns the error if failover fails

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
