### PR TITLE
fix: custom driver dialects failing due to driver registration checks

### DIFF
--- a/.test/test/dialect_manager_test/dialect_manager_test.go
+++ b/.test/test/dialect_manager_test/dialect_manager_test.go
@@ -48,22 +48,19 @@ func TestGetDialectFromConnectionParameter(t *testing.T) {
 // without requiring the wrapper driver to be registered.
 func TestGetDialectWithoutDriverRegistered(t *testing.T) {
 	tests := []struct {
-		name           string
-		dsn            string
-		driverName     string
-		driverProtocol string
+		name       string
+		dsn        string
+		driverName string
 	}{
 		{
-			name:           "postgres protocol resolves without awssql-pgx registered",
-			dsn:            pgTestDsn,
-			driverName:     driver_infrastructure.AWS_PGX_DRIVER_CODE,
-			driverProtocol: property_util.PGX_DRIVER_PROTOCOL,
+			name:       "Pg",
+			dsn:        pgTestDsn,
+			driverName: driver_infrastructure.AWS_PGX_DRIVER_CODE,
 		},
 		{
-			name:           "mysql protocol resolves without awssql-mysql registered",
-			dsn:            "someUser:somePassword@tcp(mydatabase.cluster-xyz.us-east-2.rds.amazonaws.com:3306)/myDatabase",
-			driverName:     driver_infrastructure.AWS_MYSQL_DRIVER_CODE,
-			driverProtocol: property_util.MYSQL_DRIVER_PROTOCOL,
+			name:       "MySql",
+			dsn:        "someUser:somePassword@tcp(mydatabase.cluster-xyz.us-east-2.rds.amazonaws.com:3306)/myDatabase",
+			driverName: driver_infrastructure.AWS_MYSQL_DRIVER_CODE,
 		},
 	}
 
@@ -75,12 +72,12 @@ func TestGetDialectWithoutDriverRegistered(t *testing.T) {
 			assert.Contains(t, err.Error(), "unknown driver")
 
 			// GetDialect should succeed even without the driver registered.
-			dialectManager := driver_infrastructure.DialectManager{}
-			props := test.MakeMapFromKeysAndVals(
-				property_util.DRIVER_PROTOCOL.Name, tc.driverProtocol,
-			)
-			_, err = dialectManager.GetDialect(tc.dsn, props)
+			props, parseErr := property_util.ParseDsn(tc.dsn)
+			require.NoError(t, parseErr)
 
+			dialectManager := driver_infrastructure.DialectManager{}
+			_, err = dialectManager.GetDialect(tc.dsn, props)
+			assert.NoError(t, err)
 			driver_infrastructure.ClearCaches()
 		})
 	}

--- a/.test/test/dialect_manager_test/dialect_manager_test.go
+++ b/.test/test/dialect_manager_test/dialect_manager_test.go
@@ -17,18 +17,17 @@
 package dialect_manager_test
 
 import (
+	"database/sql"
 	"strings"
 	"testing"
 
 	"github.com/aws/aws-advanced-go-wrapper/.test/test"
 	"github.com/aws/aws-advanced-go-wrapper/awssql/v2/driver_infrastructure"
-	"github.com/aws/aws-advanced-go-wrapper/awssql/v2/error_util"
 	"github.com/aws/aws-advanced-go-wrapper/awssql/v2/property_util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-var mysqlTestDsn = "someUser:somePassword@tcp(mydatabase.cluster-xyz.us-east-2.rds.amazonaws.com:3306)/myDatabase?foo=bar&pop=snap"
 var pgTestDsn = "postgres://someUser:somePassword@mydatabase.cluster-xyz.us-east-2.rds.amazonaws.com:5432/pgx_test?sslmode=disable&foo=bar"
 
 func TestGetDialectFromConnectionParameter(t *testing.T) {
@@ -45,32 +44,44 @@ func TestGetDialectFromConnectionParameter(t *testing.T) {
 	assert.True(t, strings.Contains(err.Error(), "Unknown database dialect code"))
 }
 
-func TestGetDialectUnregisteredDriverPgx(t *testing.T) {
-	findRegisteredDriver := func(dialectCode string) bool {
-		return false
+// Verifies that GetDialect resolves dialects based on driver protocol
+// without requiring the wrapper driver to be registered.
+func TestGetDialectWithoutDriverRegistered(t *testing.T) {
+	tests := []struct {
+		name           string
+		dsn            string
+		driverName     string
+		driverProtocol string
+	}{
+		{
+			name:           "postgres protocol resolves without awssql-pgx registered",
+			dsn:            pgTestDsn,
+			driverName:     driver_infrastructure.AWS_PGX_DRIVER_CODE,
+			driverProtocol: property_util.PGX_DRIVER_PROTOCOL,
+		},
+		{
+			name:           "mysql protocol resolves without awssql-mysql registered",
+			dsn:            "someUser:somePassword@tcp(mydatabase.cluster-xyz.us-east-2.rds.amazonaws.com:3306)/myDatabase",
+			driverName:     driver_infrastructure.AWS_MYSQL_DRIVER_CODE,
+			driverProtocol: property_util.MYSQL_DRIVER_PROTOCOL,
+		},
 	}
-	dialectManager := driver_infrastructure.DialectManager{FindRegisteredDriver: findRegisteredDriver}
 
-	props := test.MakeMapFromKeysAndVals(
-		property_util.DRIVER_PROTOCOL.Name, property_util.PGX_DRIVER_PROTOCOL,
-	)
-	dialect, err := dialectManager.GetDialect(pgTestDsn, props)
-	assert.Nil(t, dialect)
-	assert.Equal(t, error_util.NewGenericAwsWrapperError(error_util.GetMessage("DatabaseDialectManager.missingWrapperDriver", driver_infrastructure.AWS_PGX_DRIVER_CODE)), err)
-	driver_infrastructure.ClearCaches()
-}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Precondition: verify the driver is not registered.
+			_, err := sql.Open(tc.driverName, tc.dsn)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "unknown driver")
 
-func TestGetDialectUnregisteredDriverMysql(t *testing.T) {
-	findRegisteredDriver := func(dialectCode string) bool {
-		return false
+			// GetDialect should succeed even without the driver registered.
+			dialectManager := driver_infrastructure.DialectManager{}
+			props := test.MakeMapFromKeysAndVals(
+				property_util.DRIVER_PROTOCOL.Name, tc.driverProtocol,
+			)
+			_, err = dialectManager.GetDialect(tc.dsn, props)
+
+			driver_infrastructure.ClearCaches()
+		})
 	}
-	dialectManager := driver_infrastructure.DialectManager{FindRegisteredDriver: findRegisteredDriver}
-
-	props := test.MakeMapFromKeysAndVals(
-		property_util.DRIVER_PROTOCOL.Name, property_util.MYSQL_DRIVER_PROTOCOL,
-	)
-	dialect, err := dialectManager.GetDialect(mysqlTestDsn, props)
-	assert.Nil(t, dialect)
-	assert.Equal(t, err, error_util.NewGenericAwsWrapperError(error_util.GetMessage("DatabaseDialectManager.missingWrapperDriver", driver_infrastructure.AWS_MYSQL_DRIVER_CODE)))
-	driver_infrastructure.ClearCaches()
 }

--- a/.test/test/dialect_manager_test/dialect_manager_test.go
+++ b/.test/test/dialect_manager_test/dialect_manager_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var mysqlTestDsn = "someUser:somePassword@tcp(mydatabase.cluster-xyz.us-east-2.rds.amazonaws.com:3306)/myDatabase?foo=bar&pop=snap"
 var pgTestDsn = "postgres://someUser:somePassword@mydatabase.cluster-xyz.us-east-2.rds.amazonaws.com:5432/pgx_test?sslmode=disable&foo=bar"
 
 func TestGetDialectFromConnectionParameter(t *testing.T) {
@@ -48,19 +49,22 @@ func TestGetDialectFromConnectionParameter(t *testing.T) {
 // without requiring the wrapper driver to be registered.
 func TestGetDialectWithoutDriverRegistered(t *testing.T) {
 	tests := []struct {
-		name       string
-		dsn        string
-		driverName string
+		name            string
+		dsn             string
+		driverName      string
+		expectedDialect string
 	}{
 		{
-			name:       "Pg",
-			dsn:        pgTestDsn,
-			driverName: driver_infrastructure.AWS_PGX_DRIVER_CODE,
+			name:            "Pg",
+			dsn:             pgTestDsn,
+			driverName:      driver_infrastructure.AWS_PGX_DRIVER_CODE,
+			expectedDialect: driver_infrastructure.AURORA_PG_DIALECT,
 		},
 		{
-			name:       "MySql",
-			dsn:        "someUser:somePassword@tcp(mydatabase.cluster-xyz.us-east-2.rds.amazonaws.com:3306)/myDatabase",
-			driverName: driver_infrastructure.AWS_MYSQL_DRIVER_CODE,
+			name:            "MySql",
+			dsn:             mysqlTestDsn,
+			driverName:      driver_infrastructure.AWS_MYSQL_DRIVER_CODE,
+			expectedDialect: driver_infrastructure.AURORA_MYSQL_DIALECT,
 		},
 	}
 
@@ -76,8 +80,9 @@ func TestGetDialectWithoutDriverRegistered(t *testing.T) {
 			require.NoError(t, parseErr)
 
 			dialectManager := driver_infrastructure.DialectManager{}
-			_, err = dialectManager.GetDialect(tc.dsn, props)
-			assert.NoError(t, err)
+			dialect, err := dialectManager.GetDialect(tc.dsn, props)
+			require.NoError(t, err)
+			assert.Equal(t, driver_infrastructure.KnownDialectsByCode[tc.expectedDialect], dialect)
 			driver_infrastructure.ClearCaches()
 		})
 	}

--- a/awssql/driver_infrastructure/dialect_manager.go
+++ b/awssql/driver_infrastructure/dialect_manager.go
@@ -50,17 +50,12 @@ type DialectProvider interface {
 }
 
 type DialectManager struct {
-	canUpdate            bool
-	dialect              DatabaseDialect
-	dialectCode          string
-	FindRegisteredDriver func(dialectCode string) bool
+	canUpdate   bool
+	dialect     DatabaseDialect
+	dialectCode string
 }
 
 func (d *DialectManager) GetDialect(dsn string, props *utils.RWMap[string, string]) (DatabaseDialect, error) {
-	if d.FindRegisteredDriver == nil {
-		d.FindRegisteredDriver = utils.FindRegisteredDriver
-	}
-
 	dialectCode := property_util.DIALECT.Get(props)
 	ok := true
 	if dialectCode == "" {
@@ -86,11 +81,6 @@ func (d *DialectManager) GetDialect(dsn string, props *utils.RWMap[string, strin
 	}
 	rdsUrlType := utils.IdentifyRdsUrlType(hostString)
 	if strings.Contains(driverProtocol, "mysql") {
-		driverIsRegistered := d.FindRegisteredDriver(AWS_MYSQL_DRIVER_CODE)
-		if !driverIsRegistered {
-			return nil, error_util.NewGenericAwsWrapperError(error_util.GetMessage("DatabaseDialectManager.missingWrapperDriver", AWS_MYSQL_DRIVER_CODE))
-		}
-
 		if rdsUrlType == utils.RDS_GLOBAL_WRITER_CLUSTER {
 			d.canUpdate = false
 			d.dialectCode = GLOBAL_AURORA_MYSQL_DIALECT
@@ -121,11 +111,6 @@ func (d *DialectManager) GetDialect(dsn string, props *utils.RWMap[string, strin
 		return d.dialect, nil
 	}
 	if strings.Contains(driverProtocol, "postgres") {
-		driverIsRegistered := d.FindRegisteredDriver(AWS_PGX_DRIVER_CODE)
-		if !driverIsRegistered {
-			return nil, error_util.NewGenericAwsWrapperError(error_util.GetMessage("DatabaseDialectManager.missingWrapperDriver", AWS_PGX_DRIVER_CODE))
-		}
-
 		if rdsUrlType == utils.RDS_GLOBAL_WRITER_CLUSTER {
 			d.canUpdate = false
 			d.dialectCode = GLOBAL_AURORA_PG_DIALECT

--- a/awssql/resources/en.json
+++ b/awssql/resources/en.json
@@ -119,7 +119,6 @@
   "DatabaseDialect.usingRdsHostListProvider": "Failover is not enabled. Using RdsHostListProvider.",
   "DatabaseDialectManager.getDialectError": "Was not able to get a database dialect.",
   "DatabaseDialectManager.invalidDriverProtocol": "Invalid driver protocol from properties: %v.",
-  "DatabaseDialectManager.missingWrapperDriver": "The AWS Advanced Go Wrapper driver name '%s' has not been registered. Please ensure any required driver modules have been imported.",
   "DatabaseDialectManager.unknownDialectCode": "Unknown database dialect code: %v.",
   "DefaultConnectionPlugin.noHostsAvailable": "The default connection plugin received an empty host list from the plugin service.",
   "DefaultTelemetryFactory.invalidBackend": "Invalid telemetry backend: '%s'.",

--- a/awssql/utils/utils.go
+++ b/awssql/utils/utils.go
@@ -18,7 +18,6 @@ package utils
 
 import (
 	"context"
-	"database/sql"
 	"database/sql/driver"
 	"fmt"
 	"log/slog"
@@ -288,16 +287,6 @@ func GetHostNameFromEndpoint(endpoint string) string {
 	}
 
 	return parsedEndpoint[0]
-}
-
-func FindRegisteredDriver(dialectCode string) bool {
-	registeredDrivers := sql.Drivers()
-	for _, registeredDriver := range registeredDrivers {
-		if registeredDriver == dialectCode {
-			return true
-		}
-	}
-	return false
 }
 
 func GetQueryFromSqlOrMethodArgs(sql string, methodArgs ...any) string {


### PR DESCRIPTION
### Summary

This PRs remove checking the registered driver dialect check. Without this, custom driver dialects will be blocked as GetDialect() checks if the underlying driver is registered or not.

Related to #428.

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
