### PR TITLE
fix: pooled connections created with stale credentials

### DIFF
--- a/.test/test/internal_pooled_connection_provider_test.go
+++ b/.test/test/internal_pooled_connection_provider_test.go
@@ -115,3 +115,49 @@ func TestInternalPooledConnectionProvider_Connect(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, conn)
 }
+
+func TestInternalPooledConnectionProvider_Connect_NewConnectionsUseUpdatedPassword(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDriver := mock_database_sql_driver.NewMockDriver(ctrl)
+	mockConn1 := mock_database_sql_driver.NewMockConn(ctrl)
+	mockConn2 := mock_database_sql_driver.NewMockConn(ctrl)
+	mockPluginService := mock_driver_infrastructure.NewMockPluginService(ctrl)
+	mockDriverDialect := mock_driver_infrastructure.NewMockDriverDialect(ctrl)
+
+	opts := internal_pool.NewInternalPoolOptions(
+		internal_pool.WithMaxIdleConns(0),
+	)
+	provider := internal_pool.NewInternalPooledConnectionProvider(opts, time.Minute)
+
+	hostInfo := &host_info_util.HostInfo{Host: "test.cluster-abc123.us-east-1.rds.amazonaws.com"}
+	propsOldToken := map[string]string{"user": "user", "password": "token1"}
+	propsNewToken := map[string]string{"user": "user", "password": "token2"}
+
+	driverName := "test-driver-dsn-update"
+	awsDriver.RegisterUnderlyingDriver(driverName, mockDriver)
+	defer awsDriver.RemoveUnderlyingDriver(driverName)
+
+	mockPluginService.EXPECT().GetTargetDriverDialect().Return(mockDriverDialect)
+	mockDriverDialect.EXPECT().PrepareDsn(propsOldToken, hostInfo).Return("host=test user=testuser password=token1")
+	mockDriverDialect.EXPECT().GetDriverRegistrationName().Return(driverName)
+	mockDriver.EXPECT().Open("host=test user=testuser password=token1").Return(mockConn1, nil)
+
+	// Open initial connection with token1
+	conn1, err := provider.Connect(hostInfo, propsOldToken, mockPluginService)
+	assert.NoError(t, err)
+	assert.NotNil(t, conn1)
+	_ = conn1.Close()
+
+	// Rotate token
+	mockPluginService.EXPECT().GetTargetDriverDialect().Return(mockDriverDialect)
+	mockDriverDialect.EXPECT().PrepareDsn(propsNewToken, hostInfo).Return("host=test user=testuser password=token2")
+	mockDriverDialect.EXPECT().GetDriverRegistrationName().Return(driverName)
+	mockDriver.EXPECT().Open("host=test user=testuser password=token2").Return(mockConn2, nil)
+
+	conn2, err := provider.Connect(hostInfo, propsNewToken, mockPluginService)
+	assert.NoError(t, err)
+	assert.NotNil(t, conn2)
+	_ = conn2.Close()
+}

--- a/.test/test/internal_pooled_connection_provider_test.go
+++ b/.test/test/internal_pooled_connection_provider_test.go
@@ -144,11 +144,11 @@ func TestInternalPooledConnectionProvider_Connect_NewConnectionsUseUpdatedPasswo
 	mockDriverDialect.EXPECT().GetDriverRegistrationName().Return(driverName)
 	mockDriver.EXPECT().Open("host=test user=testuser password=token1").Return(mockConn1, nil)
 
-	// Open initial connection with token1
+	// Open initial connection with token1. Keep it checked out to force future Connect calls to create new
+	// connections via newConnFunc rather than reusing the cached token1 connection.
 	conn1, err := provider.Connect(hostInfo, propsOldToken, mockPluginService)
 	assert.NoError(t, err)
 	assert.NotNil(t, conn1)
-	_ = conn1.Close()
 
 	// Rotate token
 	mockPluginService.EXPECT().GetTargetDriverDialect().Return(mockDriverDialect)

--- a/awssql/internal_pool/internal_conn_pool.go
+++ b/awssql/internal_pool/internal_conn_pool.go
@@ -200,6 +200,12 @@ func (p *InternalConnPool) Close() error {
 	return err
 }
 
+func (p *InternalConnPool) SetNewConnFunc(f func() (driver.Conn, error)) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.newConnFunc = f
+}
+
 func (p *InternalConnPool) isConnExpired(pc *internalPooledConn, now time.Time) bool {
 	if p.maxLifetime > 0 && now.Sub(pc.createdAt) > p.maxLifetime {
 		return true

--- a/awssql/internal_pool/internal_pooled_connection_provider.go
+++ b/awssql/internal_pool/internal_pooled_connection_provider.go
@@ -30,9 +30,14 @@ import (
 
 type internalPoolKeyFunc func(*host_info_util.HostInfo, map[string]string) string
 
+type poolEntry struct {
+	pool *InternalConnPool
+	dsn  string
+}
+
 type InternalPooledConnectionProvider struct {
 	acceptedStrategies     map[string]driver_infrastructure.HostSelector
-	databasePools          *utils.SlidingExpirationCache[*InternalConnPool]
+	databasePools          *utils.SlidingExpirationCache[*poolEntry]
 	internalPoolOptions    *InternalPoolConfig
 	poolKeyFunc            internalPoolKeyFunc
 	poolExpirationDuration time.Duration
@@ -58,8 +63,8 @@ func NewInternalPooledConnectionProviderWithPoolKeyFunc(internalPoolOptions *Int
 	acceptedStrategies[driver_infrastructure.SELECTOR_ROUND_ROBIN] =
 		driver_infrastructure.GetRoundRobinHostSelector()
 
-	var disposalFunc utils.DisposalFunc[*InternalConnPool] = func(pool *InternalConnPool) bool {
-		_ = pool.Close()
+	var disposalFunc utils.DisposalFunc[*poolEntry] = func(entry *poolEntry) bool {
+		_ = entry.pool.Close()
 		return true
 	}
 	if poolExpirationDuration == 0 {
@@ -109,19 +114,29 @@ func (p *InternalPooledConnectionProvider) Connect(hostInfo *host_info_util.Host
 	driverName := driverDialect.GetDriverRegistrationName()
 	underlyingDriver := awsDriver.GetUnderlyingDriver(driverName)
 
-	computeFunc := func() *InternalConnPool {
+	computeFunc := func() *poolEntry {
 		connFunc := func() (driver.Conn, error) {
 			return underlyingDriver.Open(dsn)
 		}
 		pool := NewConnPool(connFunc, p.internalPoolOptions)
-		return pool
+		return &poolEntry{pool: pool, dsn: dsn}
 	}
 	key := p.getPoolKey(hostInfo, props)
 	poolKey := NewPoolKey(hostInfo.GetUrl(), driverName, key)
 
-	connPool := p.databasePools.ComputeIfAbsent(poolKey.String(),
+	entry := p.databasePools.ComputeIfAbsent(poolKey.String(),
 		computeFunc, p.poolExpirationDuration)
-	return connPool.Get()
+
+	if entry.dsn != dsn {
+		entry.dsn = dsn
+		// If DSN differs from the one used to initialize the cached pool entry, update the new connect func.
+		// This ensures new connections are created with the latest credentials.
+		entry.pool.SetNewConnFunc(func() (driver.Conn, error) {
+			return underlyingDriver.Open(dsn)
+		})
+	}
+
+	return entry.pool.Get()
 }
 
 func (p *InternalPooledConnectionProvider) getPoolKey(hostInfo *host_info_util.HostInfo, props map[string]string) string {


### PR DESCRIPTION
### Description

Wrapper caches the connection creation function, causing pooled connections to always be populated with the initial connection properties.
This impacts long running applications using temporary credentials, as new pooled connections created with stale credentials will fail. This PR updates the pooled connection provider's connect method to use the latest DSN when creating connections.

### Testing

- [ ] [integration test run](https://github.com/aws/aws-advanced-go-wrapper/actions/runs/25413587608)

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
