### PR TITLE
fix: minor regex fixes for mask-helper

### DIFF
--- a/.test/test/mask_helper_test.go
+++ b/.test/test/mask_helper_test.go
@@ -109,7 +109,7 @@ func TestMaskSensitiveInfoFromDsn_PgxKeywordValue(t *testing.T) {
 }
 
 func TestMaskSensitiveInfoFromDsn_PgxKeywordValue_QuotedPasswordWithSpaces(t *testing.T) {
-	dsnWithQuotedPass := "host=myHost port=5432 user=user password='my secret password' dbname=db"
+	dsnWithQuotedPass := "host=myHost port=5432 user=user password='my secret  password' dbname=db"
 	expectedMasked := "host=myHost port=5432 user=user password=*** dbname=db"
 	maskedDsn := property_util.MaskSensitiveInfoFromDsn(dsnWithQuotedPass)
 	assert.Equal(t, expectedMasked, maskedDsn)
@@ -151,7 +151,7 @@ func TestMaskSensitiveInfoFromDsn_MySQL_PasswordWithMultipleAtSigns(t *testing.T
 }
 
 func TestMaskSensitiveInfoFromDsn_MySQL_PasswordWithSpecialChars(t *testing.T) {
-	dsnWithSpecial := "someUser:pass!#$%^&*()@tcp(mydatabase.cluster-xyz.us-east-2.rds.amazonaws.com:3306)/myDatabase?foo=bar"
+	dsnWithSpecial := "someUser:pass!#$%^&*()@tcp(mydatabase.cluster-xyz.us-east-2.rds.amazonaws.com:3306)/myDatabase?foo=bar&blim=blam"
 	maskedDsn := property_util.MaskSensitiveInfoFromDsn(dsnWithSpecial)
 	assert.True(t, strings.Contains(maskedDsn, "someUser:***@tcp("))
 	assert.False(t, strings.Contains(maskedDsn, "pass"))

--- a/.test/test/mask_helper_test.go
+++ b/.test/test/mask_helper_test.go
@@ -107,3 +107,52 @@ func TestMaskSensitiveInfoFromDsn_PgxKeywordValue(t *testing.T) {
 	maskedDsn = property_util.MaskSensitiveInfoFromDsn(dsnWithNoSensitiveInfo)
 	assert.Equal(t, dsnWithNoSensitiveInfo, maskedDsn)
 }
+
+func TestMaskSensitiveInfoFromDsn_PgxKeywordValue_QuotedPasswordWithSpaces(t *testing.T) {
+	dsnWithQuotedPass := "host=myHost port=5432 user=user password='my secret password' dbname=db"
+	expectedMasked := "host=myHost port=5432 user=user password=*** dbname=db"
+	maskedDsn := property_util.MaskSensitiveInfoFromDsn(dsnWithQuotedPass)
+	assert.Equal(t, expectedMasked, maskedDsn)
+}
+
+func TestMaskSensitiveInfoFromDsn_PgxKeywordValue_QuotedPasswordWithSpecialChars(t *testing.T) {
+	dsnWithSpecialChars := "host=myHost port=5432 user=user password='p@ss=w0rd!#$' dbname=db"
+	expectedMasked := "host=myHost port=5432 user=user password=*** dbname=db"
+	maskedDsn := property_util.MaskSensitiveInfoFromDsn(dsnWithSpecialChars)
+	assert.Equal(t, expectedMasked, maskedDsn)
+}
+
+func TestMaskSensitiveInfoFromDsn_PgxKeywordValue_QuotedPasswordWithEscapedQuote(t *testing.T) {
+	dsnWithEscapedQuote := `host=myHost port=5432 user=user password='it\'s a secret' dbname=db`
+	expectedMasked := "host=myHost port=5432 user=user password=*** dbname=db"
+	maskedDsn := property_util.MaskSensitiveInfoFromDsn(dsnWithEscapedQuote)
+	assert.Equal(t, expectedMasked, maskedDsn)
+}
+
+func TestMaskSensitiveInfoFromDsn_PgxKeywordValue_QuotedIdpPassword(t *testing.T) {
+	dsn := "host=myHost port=5432 user=user password='secret pass' idpPassword='idp secret' dbname=db"
+	expectedMasked := "host=myHost port=5432 user=user password=*** idpPassword=*** dbname=db"
+	maskedDsn := property_util.MaskSensitiveInfoFromDsn(dsn)
+	assert.Equal(t, expectedMasked, maskedDsn)
+}
+
+func TestMaskSensitiveInfoFromDsn_MySQL_PasswordWithAtSign(t *testing.T) {
+	dsnWithAtInPass := "someUser:p@ssword@tcp(mydatabase.cluster-xyz.us-east-2.rds.amazonaws.com:3306)/myDatabase"
+	maskedDsn := property_util.MaskSensitiveInfoFromDsn(dsnWithAtInPass)
+	assert.True(t, strings.Contains(maskedDsn, "someUser:***@tcp("))
+	assert.False(t, strings.Contains(maskedDsn, "p@ssword"))
+}
+
+func TestMaskSensitiveInfoFromDsn_MySQL_PasswordWithMultipleAtSigns(t *testing.T) {
+	dsnWithMultiAt := "someUser:p@ss@word@tcp(mydatabase.cluster-xyz.us-east-2.rds.amazonaws.com:3306)/myDatabase"
+	maskedDsn := property_util.MaskSensitiveInfoFromDsn(dsnWithMultiAt)
+	assert.True(t, strings.Contains(maskedDsn, "someUser:***@tcp("))
+	assert.False(t, strings.Contains(maskedDsn, "p@ss@word"))
+}
+
+func TestMaskSensitiveInfoFromDsn_MySQL_PasswordWithSpecialChars(t *testing.T) {
+	dsnWithSpecial := "someUser:pass!#$%^&*()@tcp(mydatabase.cluster-xyz.us-east-2.rds.amazonaws.com:3306)/myDatabase?foo=bar"
+	maskedDsn := property_util.MaskSensitiveInfoFromDsn(dsnWithSpecial)
+	assert.True(t, strings.Contains(maskedDsn, "someUser:***@tcp("))
+	assert.False(t, strings.Contains(maskedDsn, "pass"))
+}

--- a/awssql/property_util/mask_helper.go
+++ b/awssql/property_util/mask_helper.go
@@ -36,7 +36,7 @@ func init() {
 	for k := range SENSITIVE_PROPERTIES {
 		keys = append(keys, regexp.QuoteMeta(k))
 	}
-	pgxKeywordValueRegexp = regexp.MustCompile(`\b(` + strings.Join(keys, "|") + `)=('(?:[^'\\]|\\.)*'|[^\s]+)`)
+	pgxKeywordValueRegexp = regexp.MustCompile(`\b(` + strings.Join(keys, "|") + `)=('(?:[^'\\]|\\.)*'|[^\s]*)`)
 }
 
 func maskSensitiveInfoFromPgxKeywordValue(dsn string) string {
@@ -99,7 +99,7 @@ func maskSensitiveInfoFromPgxUrl(dsn string) string {
 	return strings.ReplaceAll(u.String(), "%2A%2A%2A", "***")
 }
 
-var mysqlDsnRegexp = regexp.MustCompile(`^([^:@]+):(.+)@((?:tcp|udp|unix)?\()`)
+var mysqlDsnRegexp = regexp.MustCompile(`^([^:@]+):(.*)@((?:tcp|udp|unix)?\()`)
 
 func maskSensitiveInfoFromMySQL(dsn string) string {
 	masked := mysqlDsnRegexp.ReplaceAllString(dsn, `$1:***@$3`)

--- a/awssql/property_util/mask_helper.go
+++ b/awssql/property_util/mask_helper.go
@@ -36,7 +36,7 @@ func init() {
 	for k := range SENSITIVE_PROPERTIES {
 		keys = append(keys, regexp.QuoteMeta(k))
 	}
-	pgxKeywordValueRegexp = regexp.MustCompile(`\b(` + strings.Join(keys, "|") + `)=([^\s]+)`)
+	pgxKeywordValueRegexp = regexp.MustCompile(`\b(` + strings.Join(keys, "|") + `)=('(?:[^'\\]|\\.)*'|[^\s]+)`)
 }
 
 func maskSensitiveInfoFromPgxKeywordValue(dsn string) string {
@@ -99,10 +99,10 @@ func maskSensitiveInfoFromPgxUrl(dsn string) string {
 	return strings.ReplaceAll(u.String(), "%2A%2A%2A", "***")
 }
 
-var mysqlDsnRegexp = regexp.MustCompile(`(?P<user>[^:]+):(?P<password>[^@]+)@`)
+var mysqlDsnRegexp = regexp.MustCompile(`^([^:@]+):(.+)@((?:tcp|udp|unix)?\()`)
 
 func maskSensitiveInfoFromMySQL(dsn string) string {
-	masked := mysqlDsnRegexp.ReplaceAllString(dsn, `${user}:***@`)
+	masked := mysqlDsnRegexp.ReplaceAllString(dsn, `$1:***@$3`)
 
 	parts := strings.SplitN(masked, "?", 2)
 	if len(parts) == 2 {


### PR DESCRIPTION
### Summary

<!--- General summary / title -->

### Description
Minor fixes to mask-helper to address scenarios of spaces and special characters in passwords, and quoted passwords. 

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
