### PR TITLE
fix(error-handler): exclude caller cancellation & stale-conn from IsNetworkError

### DIFF
--- a/.test/test/mysql_driver_dialect_test.go
+++ b/.test/test/mysql_driver_dialect_test.go
@@ -17,10 +17,15 @@
 package test
 
 import (
+	"context"
+	"database/sql/driver"
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/aws/aws-advanced-go-wrapper/awssql/v2/property_util"
 	mysql_driver "github.com/aws/aws-advanced-go-wrapper/mysql-driver"
+	"github.com/go-sql-driver/mysql"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -88,6 +93,44 @@ func TestPrepareDsnWithoutPasswordOrPort(t *testing.T) {
 
 	dsn := driverDialect.PrepareDsn(properties, nil)
 	assert.Equal(t, "user@tcp(host)/dbName", dsn)
+}
+
+func TestMySQLErrorHandler_IsNetworkError(t *testing.T) {
+	handler := mysql_driver.MySQLErrorHandler{}
+
+	t.Run("substring network errors", func(t *testing.T) {
+		for _, message := range mysql_driver.MySqlNetworkErrorMessages {
+			assert.True(t, handler.IsNetworkError(errors.New(message)), "expected network error for: %s", message)
+		}
+	})
+
+	t.Run("SQLSTATE 08 class is a network error", func(t *testing.T) {
+		err := &mysql.MySQLError{SQLState: [5]byte{'0', '8', '0', '0', '6'}, Message: "conn"}
+		assert.True(t, handler.IsNetworkError(err))
+	})
+
+	t.Run("caller cancellation is not a network error", func(t *testing.T) {
+		assert.False(t, handler.IsNetworkError(context.Canceled))
+		assert.False(t, handler.IsNetworkError(fmt.Errorf("query aborted: %w", context.Canceled)))
+		assert.False(t, handler.IsNetworkError(context.DeadlineExceeded))
+		assert.False(t, handler.IsNetworkError(fmt.Errorf("read timed out: %w", context.DeadlineExceeded)))
+	})
+
+	t.Run("driver.ErrBadConn is not a network error", func(t *testing.T) {
+		assert.False(t, handler.IsNetworkError(driver.ErrBadConn))
+		assert.False(t, handler.IsNetworkError(fmt.Errorf("wrapped: %w", driver.ErrBadConn)))
+	})
+
+	t.Run("mysql.ErrInvalidConn is a network error", func(t *testing.T) {
+		// go-sql-driver/mysql returns ErrInvalidConn from readPacket/writePacket
+		// on non-cancellation I/O failures — a genuine network failure signal.
+		assert.True(t, handler.IsNetworkError(mysql.ErrInvalidConn))
+		assert.True(t, handler.IsNetworkError(fmt.Errorf("wrapped: %w", mysql.ErrInvalidConn)))
+	})
+
+	t.Run("non-network errors", func(t *testing.T) {
+		assert.False(t, handler.IsNetworkError(errors.New("duplicate entry")))
+	})
 }
 
 func TestPrepareDsnWithoutHost(t *testing.T) {

--- a/.test/test/pgx_driver_dialect_test.go
+++ b/.test/test/pgx_driver_dialect_test.go
@@ -17,6 +17,8 @@
 package test
 
 import (
+	"context"
+	"database/sql/driver"
 	"errors"
 	"fmt"
 	"regexp"
@@ -71,4 +73,23 @@ func TestPgxErrorHandler(t *testing.T) {
 		assert.False(t, errorHandler.IsNetworkError(err))
 		assert.True(t, errorHandler.IsLoginError(err))
 	}
+}
+
+func TestPgxErrorHandler_CallerCancellationAndStaleConn(t *testing.T) {
+	errorHandler := &pgx_driver.PgxErrorHandler{}
+
+	t.Run("context.Canceled is not a network error", func(t *testing.T) {
+		assert.False(t, errorHandler.IsNetworkError(context.Canceled))
+		assert.False(t, errorHandler.IsNetworkError(fmt.Errorf("query aborted: %w", context.Canceled)))
+	})
+
+	t.Run("context.DeadlineExceeded is not a network error", func(t *testing.T) {
+		assert.False(t, errorHandler.IsNetworkError(context.DeadlineExceeded))
+		assert.False(t, errorHandler.IsNetworkError(fmt.Errorf("read timed out: %w", context.DeadlineExceeded)))
+	})
+
+	t.Run("driver.ErrBadConn is not a network error", func(t *testing.T) {
+		assert.False(t, errorHandler.IsNetworkError(driver.ErrBadConn))
+		assert.False(t, errorHandler.IsNetworkError(fmt.Errorf("wrapped: %w", driver.ErrBadConn)))
+	})
 }

--- a/bun-pg-driver/bun_error_handler.go
+++ b/bun-pg-driver/bun_error_handler.go
@@ -17,6 +17,8 @@
 package bun_pg_driver
 
 import (
+	"context"
+	"database/sql/driver"
 	"errors"
 	"slices"
 	"strings"
@@ -44,13 +46,22 @@ var PgNetworkErrorMessages = []string{
 	"unexpected EOF",
 	"use of closed network connection",
 	"broken pipe",
-	"bad connection",
-	"context deadline exceeded",
 }
 
 type BunPgErrorHandler struct{}
 
 func (h *BunPgErrorHandler) IsNetworkError(err error) bool {
+	// Caller-initiated cancellation / deadline is not a DB network failure.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	// driver.ErrBadConn is database/sql's signal that a cached conn is stale;
+	// database/sql discards it and retries on a fresh connection. Genuine
+	// server/network faults surface as SQLSTATE 08xxx/57P01 or raw I/O errors.
+	if errors.Is(err, driver.ErrBadConn) {
+		return false
+	}
+
 	sqlState := h.getSQLStateFromError(err)
 	if sqlState != "" && slices.Contains(NetworkErrors, sqlState) {
 		return true

--- a/bun-pg-driver/bun_error_handler_test.go
+++ b/bun-pg-driver/bun_error_handler_test.go
@@ -17,6 +17,8 @@
 package bun_pg_driver
 
 import (
+	"context"
+	"database/sql/driver"
 	"fmt"
 	"testing"
 
@@ -31,13 +33,23 @@ func TestBunPgErrorHandler_IsNetworkError(t *testing.T) {
 		assert.True(t, h.IsNetworkError(fmt.Errorf("unexpected EOF")))
 		assert.True(t, h.IsNetworkError(fmt.Errorf("read: use of closed network connection")))
 		assert.True(t, h.IsNetworkError(fmt.Errorf("write: broken pipe")))
-		assert.True(t, h.IsNetworkError(fmt.Errorf("bad connection")))
-		assert.True(t, h.IsNetworkError(fmt.Errorf("context deadline exceeded")))
 	})
 
 	t.Run("non-network errors", func(t *testing.T) {
 		assert.False(t, h.IsNetworkError(fmt.Errorf("unique constraint violation")))
 		assert.False(t, h.IsNetworkError(fmt.Errorf("serialization failure")))
+	})
+
+	t.Run("caller cancellation is not a network error", func(t *testing.T) {
+		assert.False(t, h.IsNetworkError(context.Canceled))
+		assert.False(t, h.IsNetworkError(fmt.Errorf("query aborted: %w", context.Canceled)))
+		assert.False(t, h.IsNetworkError(context.DeadlineExceeded))
+		assert.False(t, h.IsNetworkError(fmt.Errorf("read timed out: %w", context.DeadlineExceeded)))
+	})
+
+	t.Run("driver.ErrBadConn is not a network error", func(t *testing.T) {
+		assert.False(t, h.IsNetworkError(driver.ErrBadConn))
+		assert.False(t, h.IsNetworkError(fmt.Errorf("wrapped: %w", driver.ErrBadConn)))
 	})
 }
 

--- a/mysql-driver/mysql_error_handler.go
+++ b/mysql-driver/mysql_error_handler.go
@@ -17,6 +17,8 @@
 package mysql_driver
 
 import (
+	"context"
+	"database/sql/driver"
 	"errors"
 	"strings"
 
@@ -26,16 +28,29 @@ import (
 const SqlStateAccessError = "28000"
 
 var MySqlNetworkErrorMessages = []string{
-	"invalid connection",
-	"bad connection",
 	"broken pipe",
-	"context deadline exceeded",
 }
 
 type MySQLErrorHandler struct {
 }
 
 func (m MySQLErrorHandler) IsNetworkError(err error) bool {
+	// Caller-initiated cancellation / deadline is not a DB network failure.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	// driver.ErrBadConn is database/sql's stale-conn signal; it discards the
+	// cached conn and retries on a fresh one. Not a network fault.
+	if errors.Is(err, driver.ErrBadConn) {
+		return false
+	}
+	// mysql.ErrInvalidConn is returned by go-sql-driver/mysql from
+	// readPacket/writePacket when the underlying net.Conn fails mid-query
+	// (after a non-cancellation I/O error); it IS a genuine network failure.
+	if errors.Is(err, mysql.ErrInvalidConn) {
+		return true
+	}
+
 	sqlState := m.getSQLStateFromError(err)
 	if sqlState != "" && string(sqlState[0:2]) == "08" {
 		return true

--- a/pgx-driver/pgx_error_handler.go
+++ b/pgx-driver/pgx_error_handler.go
@@ -17,6 +17,8 @@
 package pgx_driver
 
 import (
+	"context"
+	"database/sql/driver"
 	"errors"
 	"slices"
 	"strings"
@@ -44,14 +46,22 @@ var PgNetworkErrorMessages = []string{
 	"unexpected EOF",
 	"use of closed network connection",
 	"broken pipe",
-	"bad connection",
-	"context deadline exceeded",
 }
 
 type PgxErrorHandler struct {
 }
 
 func (p *PgxErrorHandler) IsNetworkError(err error) bool {
+	// Caller-initiated cancellation / deadline is not a DB network failure.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	// driver.ErrBadConn is database/sql's stale-conn signal; it discards the
+	// cached conn and retries on a fresh one. Not a network fault.
+	if errors.Is(err, driver.ErrBadConn) {
+		return false
+	}
+
 	sqlState := p.getSQLStateFromError(err)
 
 	if sqlState != "" && slices.Contains(NetworkErrors, sqlState) {


### PR DESCRIPTION
### Summary

Exclude caller-initiated cancellation (`context.Canceled`, `context.DeadlineExceeded`) and `database/sql`'s stale-connection sentinel (`driver.ErrBadConn`) from `IsNetworkError` in the pgx, bun-pg, and mysql error handlers, so a cancelled client request no longer triggers a spurious failover. Addresses #492.

### Description

**What changed**

- `pgx-driver/pgx_error_handler.go`, `bun-pg-driver/bun_error_handler.go`: short-circuit `errors.Is(err, context.Canceled | context.DeadlineExceeded | driver.ErrBadConn)` → `false`. Drop `"bad connection"` and `"context deadline exceeded"` from `PgNetworkErrorMessages`.
- `mysql-driver/mysql_error_handler.go`: same short-circuit for stdlib sentinels; add positive branch `errors.Is(err, mysql.ErrInvalidConn)` → `true` — `go-sql-driver/mysql` returns this from `readPacket`/`writePacket` on non-cancellation I/O failures (a genuine wire-level drop). Drop `"invalid connection"`, `"bad connection"`, `"context deadline exceeded"` from `MySqlNetworkErrorMessages`.
- Tests: cover bare sentinels and `%w`-wrapped variants for all three handlers; add explicit assertion that `mysql.ErrInvalidConn` remains a network error.

**Rationale**

- `driver.ErrBadConn` is `database/sql`'s signal that a cached connection is stale; the runtime discards it and retries on a fresh conn transparently. It is not, by itself, a network fault. In the reported reproduction, pgx closes the underlying conn on `ctx.Cancel()` and the next operation returns `driver.ErrBadConn` — previously misclassified as network failure and triggering failover.
- `pgconn.normalizeTimeoutError` in pgx wraps I/O timeouts/cancellations into `context.Canceled` / `context.DeadlineExceeded`, so `errors.Is` catches wrapped variants originating from other pgx call paths.
- Genuine network faults still trigger failover: SQLSTATE 08xxx / 57P01 (pg family), SQLSTATE 08 class (mysql), raw `"unexpected EOF"` / `"broken pipe"` / `"use of closed network connection"` (pg family), `"broken pipe"` (mysql), and `mysql.ErrInvalidConn` (mysql).

**Scope**

Addresses the main classification bug from #492. The SQLSTATE class-prefix matching bug mentioned in the same issue's "Additional Information/Context" section is intentionally left out to keep this change focused; it can be handled in a separate follow-up PR.

**Test plan**

- [x] `cd .test && go test ./test/...` (all pass)
- [x] `cd bun-pg-driver && go test ./...` (all pass)
- [x] Manual verification against a local PostgreSQL using the reproduction from #492: before fix, `context canceled` on `QueryRowContext` was followed by `driver: bad connection` on the next op and `Starting writer failover procedure.` fired (×2); after fix, the same follow-up produces no failover log and `database/sql` transparently gets a fresh conn.
- [ ] Manual verification against Aurora MySQL: mid-query TCP drop still triggers failover via the `mysql.ErrInvalidConn` positive branch.

### Additional Reviewers



### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.