### PR TITLE
fix: coalesce concurrent monitor initialization (#502)

### DIFF
--- a/.test/test/services/monitor_test.go
+++ b/.test/test/services/monitor_test.go
@@ -728,6 +728,63 @@ func TestMonitorManagerRunIfAbsentRetriesAfterInitializationError(t *testing.T) 
 	assert.Equal(t, int32(1), mock.startCount.Load())
 }
 
+func TestMonitorManagerRunIfAbsentInitializerPanicUnblocksWaiters(t *testing.T) {
+	publisher := services.NewBatchingEventPublisher(1 * time.Hour)
+	defer publisher.Stop()
+	manager := services.NewMonitorManager(1*time.Hour, publisher)
+	defer manager.ReleaseResources()
+
+	initializerEntered := make(chan struct{})
+	releaseInitializer := make(chan struct{})
+
+	leaderPanic := make(chan any, 1)
+	go func() {
+		defer func() { leaderPanic <- recover() }()
+		_, _ = manager.RunIfAbsent(testMonitorType, "panic-key", nil, func(_ driver_infrastructure.ServicesContainer) (driver_infrastructure.Monitor, error) {
+			close(initializerEntered)
+			<-releaseInitializer
+			panic("initializer panicked")
+		})
+	}()
+	<-initializerEntered
+
+	var waiterInitializerCalls atomic.Int32
+	waiterDone := make(chan struct{})
+	var waiterMonitor driver_infrastructure.Monitor
+	var waiterErr error
+	go func() {
+		defer close(waiterDone)
+		waiterMonitor, waiterErr = manager.RunIfAbsent(testMonitorType, "panic-key", nil, func(_ driver_infrastructure.ServicesContainer) (driver_infrastructure.Monitor, error) {
+			waiterInitializerCalls.Add(1)
+			return newMockMonitor(), nil
+		})
+	}()
+	time.Sleep(50 * time.Millisecond)
+	close(releaseInitializer)
+
+	select {
+	case recovered := <-leaderPanic:
+		assert.Equal(t, "initializer panicked", recovered)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for the panicking caller")
+	}
+	select {
+	case <-waiterDone:
+	case <-time.After(time.Second):
+		t.Fatal("waiter was not unblocked after the initializer panicked")
+	}
+	assert.Error(t, waiterErr)
+	assert.Nil(t, waiterMonitor)
+	assert.Equal(t, int32(0), waiterInitializerCalls.Load())
+
+	mock := newMockMonitor()
+	monitor, err := manager.RunIfAbsent(testMonitorType, "panic-key", nil, func(_ driver_infrastructure.ServicesContainer) (driver_infrastructure.Monitor, error) {
+		return mock, nil
+	})
+	assert.NoError(t, err)
+	assert.Same(t, mock, monitor)
+}
+
 func TestMonitorManagerRemoveNonExistentType(t *testing.T) {
 	publisher := services.NewBatchingEventPublisher(1 * time.Hour)
 	defer publisher.Stop()

--- a/.test/test/services/monitor_test.go
+++ b/.test/test/services/monitor_test.go
@@ -18,6 +18,7 @@ package services
 
 import (
 	"errors"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -30,6 +31,7 @@ import (
 // mockMonitor is a simple mock for the Monitor interface used in monitor manager tests.
 type mockMonitor struct {
 	started       atomic.Bool
+	startCount    atomic.Int32
 	stopped       atomic.Bool
 	state         driver_infrastructure.MonitorState
 	lastActivity  int64
@@ -45,7 +47,10 @@ func newMockMonitor() *mockMonitor {
 	}
 }
 
-func (m *mockMonitor) Start()   { m.started.Store(true) }
+func (m *mockMonitor) Start() {
+	m.startCount.Add(1)
+	m.started.Store(true)
+}
 func (m *mockMonitor) Monitor() { m.monitorCalled.Store(true) }
 func (m *mockMonitor) Stop()    { m.stopped.Store(true) }
 func (m *mockMonitor) Close()   {}
@@ -99,6 +104,95 @@ func TestMonitorManagerRunIfAbsentReturnsExisting(t *testing.T) {
 
 	assert.Equal(t, monitor1, monitor2)
 	assert.Equal(t, 1, callCount) // initializer should only be called once
+}
+
+func TestMonitorManagerRunIfAbsentInitializesOnceConcurrently(t *testing.T) {
+	publisher := services.NewBatchingEventPublisher(1 * time.Hour)
+	defer publisher.Stop()
+	manager := services.NewMonitorManager(1*time.Hour, publisher)
+	defer manager.ReleaseResources()
+
+	const callerCount = 100
+	startCalls := make(chan struct{})
+	releaseInitializer := make(chan struct{})
+	allCallsStarted := make(chan struct{})
+	results := make([]driver_infrastructure.Monitor, callerCount)
+	errs := make([]error, callerCount)
+
+	mock := newMockMonitor()
+	var initializerCalls atomic.Int32
+	initializer := func(_ driver_infrastructure.ServicesContainer) (driver_infrastructure.Monitor, error) {
+		initializerCalls.Add(1)
+		<-releaseInitializer
+		return mock, nil
+	}
+
+	var callsStarted atomic.Int32
+	var wg sync.WaitGroup
+	wg.Add(callerCount)
+	for i := range callerCount {
+		go func() {
+			defer wg.Done()
+			<-startCalls
+			if callsStarted.Add(1) == callerCount {
+				close(allCallsStarted)
+			}
+			results[i], errs[i] = manager.RunIfAbsent(testMonitorType, "shared-key", nil, initializer)
+		}()
+	}
+
+	close(startCalls)
+	select {
+	case <-allCallsStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for concurrent callers")
+	}
+	time.Sleep(50 * time.Millisecond)
+	close(releaseInitializer)
+	wg.Wait()
+
+	assert.Equal(t, int32(1), initializerCalls.Load())
+	assert.Equal(t, int32(1), mock.startCount.Load())
+	for i := range callerCount {
+		assert.NoError(t, errs[i])
+		assert.Same(t, mock, results[i])
+	}
+}
+
+func TestMonitorManagerRunIfAbsentInitializesDifferentKeysConcurrently(t *testing.T) {
+	publisher := services.NewBatchingEventPublisher(1 * time.Hour)
+	defer publisher.Stop()
+	manager := services.NewMonitorManager(1*time.Hour, publisher)
+	defer manager.ReleaseResources()
+
+	firstInitializerStarted := make(chan struct{})
+	releaseFirstInitializer := make(chan struct{})
+	firstCallDone := make(chan struct{})
+	go func() {
+		defer close(firstCallDone)
+		_, _ = manager.RunIfAbsent(testMonitorType, "key1", nil, func(_ driver_infrastructure.ServicesContainer) (driver_infrastructure.Monitor, error) {
+			close(firstInitializerStarted)
+			<-releaseFirstInitializer
+			return newMockMonitor(), nil
+		})
+	}()
+	<-firstInitializerStarted
+
+	secondCallDone := make(chan struct{})
+	go func() {
+		defer close(secondCallDone)
+		_, _ = manager.RunIfAbsent(testMonitorType, "key2", nil, func(_ driver_infrastructure.ServicesContainer) (driver_infrastructure.Monitor, error) {
+			return newMockMonitor(), nil
+		})
+	}()
+
+	select {
+	case <-secondCallDone:
+	case <-time.After(time.Second):
+		t.Fatal("initialization for a different key was blocked")
+	}
+	close(releaseFirstInitializer)
+	<-firstCallDone
 }
 
 func TestMonitorManagerGet(t *testing.T) {
@@ -544,6 +638,33 @@ func TestMonitorManagerRunIfAbsentError(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Equal(t, expectedErr, err)
 	assert.Nil(t, monitor)
+}
+
+func TestMonitorManagerRunIfAbsentRetriesAfterInitializationError(t *testing.T) {
+	publisher := services.NewBatchingEventPublisher(1 * time.Hour)
+	defer publisher.Stop()
+	manager := services.NewMonitorManager(1*time.Hour, publisher)
+	defer manager.ReleaseResources()
+
+	expectedErr := errors.New("initializer failed")
+	mock := newMockMonitor()
+	var initializerCalls atomic.Int32
+	initializer := func(_ driver_infrastructure.ServicesContainer) (driver_infrastructure.Monitor, error) {
+		if initializerCalls.Add(1) == 1 {
+			return nil, expectedErr
+		}
+		return mock, nil
+	}
+
+	monitor, err := manager.RunIfAbsent(testMonitorType, "retry-key", nil, initializer)
+	assert.ErrorIs(t, err, expectedErr)
+	assert.Nil(t, monitor)
+
+	monitor, err = manager.RunIfAbsent(testMonitorType, "retry-key", nil, initializer)
+	assert.NoError(t, err)
+	assert.Same(t, mock, monitor)
+	assert.Equal(t, int32(2), initializerCalls.Load())
+	assert.Equal(t, int32(1), mock.startCount.Load())
 }
 
 func TestMonitorManagerRemoveNonExistentType(t *testing.T) {

--- a/.test/test/services/monitor_test.go
+++ b/.test/test/services/monitor_test.go
@@ -37,6 +37,9 @@ type mockMonitor struct {
 	lastActivity  int64
 	canDispose    bool
 	monitorCalled atomic.Bool
+	startEntered  chan struct{}
+	releaseStart  chan struct{}
+	stateChecked  chan struct{}
 }
 
 func newMockMonitor() *mockMonitor {
@@ -48,6 +51,13 @@ func newMockMonitor() *mockMonitor {
 }
 
 func (m *mockMonitor) Start() {
+	if m.startEntered != nil {
+		close(m.startEntered)
+	}
+	if m.releaseStart != nil {
+		<-m.releaseStart
+		m.state = driver_infrastructure.MonitorStateRunning
+	}
 	m.startCount.Add(1)
 	m.started.Store(true)
 }
@@ -58,6 +68,12 @@ func (m *mockMonitor) GetLastActivityTimestampNanos() int64 {
 	return m.lastActivity
 }
 func (m *mockMonitor) GetState() driver_infrastructure.MonitorState {
+	if m.stateChecked != nil {
+		select {
+		case m.stateChecked <- struct{}{}:
+		default:
+		}
+	}
 	return m.state
 }
 func (m *mockMonitor) CanDispose() bool {
@@ -193,6 +209,51 @@ func TestMonitorManagerRunIfAbsentInitializesDifferentKeysConcurrently(t *testin
 	}
 	close(releaseFirstInitializer)
 	<-firstCallDone
+}
+
+func TestMonitorManagerCleanupWaitsForInitialization(t *testing.T) {
+	publisher := services.NewBatchingEventPublisher(1 * time.Hour)
+	defer publisher.Stop()
+	manager := services.NewMonitorManager(time.Millisecond, publisher)
+	defer manager.ReleaseResources()
+
+	mock := newMockMonitor()
+	mock.state = driver_infrastructure.MonitorStateStopped
+	mock.startEntered = make(chan struct{})
+	mock.releaseStart = make(chan struct{})
+	mock.stateChecked = make(chan struct{}, 1)
+
+	var initializerCalls atomic.Int32
+	initializer := func(_ driver_infrastructure.ServicesContainer) (driver_infrastructure.Monitor, error) {
+		initializerCalls.Add(1)
+		return mock, nil
+	}
+
+	firstCallDone := make(chan struct{})
+	var firstMonitor driver_infrastructure.Monitor
+	var firstErr error
+	go func() {
+		defer close(firstCallDone)
+		firstMonitor, firstErr = manager.RunIfAbsent(testMonitorType, "shared-key", nil, initializer)
+	}()
+
+	<-mock.startEntered
+	cleanupRanDuringStart := false
+	select {
+	case <-mock.stateChecked:
+		cleanupRanDuringStart = true
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(mock.releaseStart)
+	<-firstCallDone
+
+	assert.False(t, cleanupRanDuringStart)
+	assert.NoError(t, firstErr)
+
+	secondMonitor, secondErr := manager.RunIfAbsent(testMonitorType, "shared-key", nil, initializer)
+	assert.NoError(t, secondErr)
+	assert.Same(t, firstMonitor, secondMonitor)
+	assert.Equal(t, int32(1), initializerCalls.Load())
 }
 
 func TestMonitorManagerGet(t *testing.T) {

--- a/awssql/resources/en.json
+++ b/awssql/resources/en.json
@@ -242,6 +242,7 @@
   "HostMonitorImpl.updatingActiveStates": "Updating active states for %v. Going from %v state(s) to %v.",
   "HostMonitoringServiceImpl.errorAbortingConn": "An error was thrown when aborting monitoring Conn: %v.",
   "HostMonitoringServiceImpl.illegalArgumentError": "Illegal argument for '%v' was given to HostMonitoringServiceImpl.",
+  "MonitorManager.initializationPanicked": "Monitor initialization panicked.",
   "OktaAuthPlugin.failedSamlAssertion": "Could not get SAML response from the following endpoint: '%v'.",
   "OktaAuthPlugin.httpNon200StatusCode": "Did not get a 200 response from http request to '%v'. Received the following status code: '%v'.",
   "OktaAuthPlugin.unableToDetermineRegion": "Unable to determine the region. Please set the '%v' parameter.",

--- a/awssql/services/monitor.go
+++ b/awssql/services/monitor.go
@@ -17,6 +17,7 @@
 package services
 
 import (
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -46,11 +47,62 @@ type monitorItem struct {
 	expiresAt       atomic.Int64 // unix nano timestamp
 }
 
+type monitorInitialization struct {
+	done    chan struct{}
+	monitor driver_infrastructure.Monitor
+	err     error
+}
+
 // cacheContainer holds a cache of monitors with related settings.
 type cacheContainer struct {
-	settings         *driver_infrastructure.MonitorSettings
-	cache            *utils.RWMap[any, *monitorItem]
-	producedDataType string // The type key of data produced by this monitor type
+	settings               *driver_infrastructure.MonitorSettings
+	cache                  *utils.RWMap[any, *monitorItem]
+	producedDataType       string // The type key of data produced by this monitor type
+	initializationLock     sync.Mutex
+	monitorInitializations map[any]*monitorInitialization
+}
+
+func (c *cacheContainer) runIfAbsent(
+	key any,
+	monitorSupplier func() (driver_infrastructure.Monitor, error),
+) (driver_infrastructure.Monitor, error) {
+	c.initializationLock.Lock()
+	if existingItem, exists := c.cache.Get(key); exists && existingItem != nil {
+		existingItem.expiresAt.Store(time.Now().Add(c.settings.ExpirationTimeout).UnixNano())
+		c.initializationLock.Unlock()
+		return existingItem.monitor, nil
+	}
+
+	if initialization, exists := c.monitorInitializations[key]; exists {
+		c.initializationLock.Unlock()
+		<-initialization.done
+		return initialization.monitor, initialization.err
+	}
+
+	initialization := &monitorInitialization{done: make(chan struct{})}
+	c.monitorInitializations[key] = initialization
+	c.initializationLock.Unlock()
+
+	monitor, err := monitorSupplier()
+	if err == nil {
+		item := &monitorItem{
+			monitor:         monitor,
+			monitorSupplier: monitorSupplier,
+		}
+		item.expiresAt.Store(time.Now().Add(c.settings.ExpirationTimeout).UnixNano())
+
+		c.cache.Put(key, item)
+		monitor.Start()
+	}
+
+	c.initializationLock.Lock()
+	initialization.monitor = monitor
+	initialization.err = err
+	delete(c.monitorInitializations, key)
+	close(initialization.done)
+	c.initializationLock.Unlock()
+
+	return monitor, err
 }
 
 // MonitorManager manages background monitors with expiration and health checks.
@@ -118,9 +170,10 @@ func (m *MonitorManager) RegisterMonitorType(
 	producedDataType string,
 ) {
 	m.monitorCaches.PutIfAbsent(monitorType.Name, &cacheContainer{
-		settings:         settings,
-		cache:            utils.NewRWMap[any, *monitorItem](),
-		producedDataType: producedDataType,
+		settings:               settings,
+		cache:                  utils.NewRWMap[any, *monitorItem](),
+		producedDataType:       producedDataType,
+		monitorInitializations: make(map[any]*monitorInitialization),
 	})
 }
 
@@ -138,34 +191,10 @@ func (m *MonitorManager) RunIfAbsent(
 		cacheContainer, _ = m.monitorCaches.Get(monitorType.Name)
 	}
 
-	// Check if monitor already exists
-	existingItem, exists := cacheContainer.cache.Get(key)
-	if exists && existingItem != nil {
-		// Extend expiration
-		existingItem.expiresAt.Store(time.Now().Add(cacheContainer.settings.ExpirationTimeout).UnixNano())
-		return existingItem.monitor, nil
-	}
-
-	// Create new monitor
 	monitorSupplier := func() (driver_infrastructure.Monitor, error) {
 		return initializer(container)
 	}
-
-	monitor, err := monitorSupplier()
-	if err != nil {
-		return nil, err
-	}
-
-	item := &monitorItem{
-		monitor:         monitor,
-		monitorSupplier: monitorSupplier,
-	}
-	item.expiresAt.Store(time.Now().Add(cacheContainer.settings.ExpirationTimeout).UnixNano())
-
-	cacheContainer.cache.PutIfAbsent(key, item)
-	monitor.Start()
-
-	return monitor, nil
+	return cacheContainer.runIfAbsent(key, monitorSupplier)
 }
 
 // Get retrieves a monitor by type and key.
@@ -302,19 +331,6 @@ func (m *MonitorManager) handleMonitorError(container *cacheContainer, key any, 
 
 	// Check if we should recreate the monitor
 	if container.settings.ErrorResponses[driver_infrastructure.MonitorErrorRecreate] {
-		// Try to recreate the monitor
-		newMonitor, err := errorItem.monitorSupplier()
-		if err != nil {
-			return
-		}
-
-		newItem := &monitorItem{
-			monitor:         newMonitor,
-			monitorSupplier: errorItem.monitorSupplier,
-		}
-		newItem.expiresAt.Store(time.Now().Add(container.settings.ExpirationTimeout).UnixNano())
-
-		container.cache.PutIfAbsent(key, newItem)
-		newMonitor.Start()
+		_, _ = container.runIfAbsent(key, errorItem.monitorSupplier)
 	}
 }

--- a/awssql/services/monitor.go
+++ b/awssql/services/monitor.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-advanced-go-wrapper/awssql/v2/driver_infrastructure"
+	"github.com/aws/aws-advanced-go-wrapper/awssql/v2/error_util"
 	"github.com/aws/aws-advanced-go-wrapper/awssql/v2/utils"
 )
 
@@ -105,25 +106,51 @@ func (c *cacheContainer) runIfAbsent(
 	c.monitorInitializations[key] = initialization
 	c.initializationLock.Unlock()
 
-	monitor, err := monitorSupplier()
-	c.initializationLock.Lock()
-	if err == nil {
-		item := &monitorItem{
-			monitor:         monitor,
-			monitorSupplier: monitorSupplier,
+	return c.initializeMonitor(key, initialization, monitorSupplier)
+}
+
+// initializeMonitor invokes monitorSupplier and publishes the result to
+// same-key callers waiting on initialization. Publication runs in a defer so
+// that a panicking supplier still unblocks waiters with an error and clears
+// the in-flight entry; otherwise every later same-key call would block
+// forever. The panic itself continues to propagate to this caller.
+func (c *cacheContainer) initializeMonitor(
+	key any,
+	initialization *monitorInitialization,
+	monitorSupplier func() (driver_infrastructure.Monitor, error),
+) (monitor driver_infrastructure.Monitor, err error) {
+	completed := false
+	defer func() {
+		if !completed {
+			monitor = nil
+			err = error_util.NewGenericAwsWrapperError(error_util.GetMessage("MonitorManager.initializationPanicked"))
 		}
-		item.expiresAt.Store(time.Now().Add(c.settings.ExpirationTimeout).UnixNano())
 
-		c.cache.Put(key, item)
-		monitor.Start()
-	}
+		c.initializationLock.Lock()
+		defer c.initializationLock.Unlock()
 
-	initialization.monitor = monitor
-	initialization.err = err
-	delete(c.monitorInitializations, key)
-	close(initialization.done)
-	c.initializationLock.Unlock()
+		initialization.monitor = monitor
+		initialization.err = err
+		delete(c.monitorInitializations, key)
+		// done is closed via defer so waiters are unblocked even if Start panics.
+		defer close(initialization.done)
 
+		if err == nil {
+			item := &monitorItem{
+				monitor:         monitor,
+				monitorSupplier: monitorSupplier,
+			}
+			item.expiresAt.Store(time.Now().Add(c.settings.ExpirationTimeout).UnixNano())
+
+			// Cache insertion and Start stay under initializationLock so the
+			// cleanup loop cannot dispose a monitor that has not started yet.
+			c.cache.Put(key, item)
+			monitor.Start()
+		}
+	}()
+
+	monitor, err = monitorSupplier()
+	completed = true
 	return monitor, err
 }
 

--- a/awssql/services/monitor.go
+++ b/awssql/services/monitor.go
@@ -62,15 +62,37 @@ type cacheContainer struct {
 	monitorInitializations map[any]*monitorInitialization
 }
 
+// getAndExtendExpiration returns the cached monitor for key, extending its
+// expiration, or false if no monitor is cached.
+func (c *cacheContainer) getAndExtendExpiration(key any) (driver_infrastructure.Monitor, bool) {
+	item, exists := c.cache.Get(key)
+	if !exists || item == nil {
+		return nil, false
+	}
+	item.expiresAt.Store(time.Now().Add(c.settings.ExpirationTimeout).UnixNano())
+	return item.monitor, true
+}
+
+// runIfAbsent returns the cached monitor for key, coalescing concurrent
+// initialization so that exactly one caller invokes monitorSupplier while
+// concurrent same-key callers wait for and share its result. A failed
+// initialization is not cached, so a later call can retry.
 func (c *cacheContainer) runIfAbsent(
 	key any,
 	monitorSupplier func() (driver_infrastructure.Monitor, error),
 ) (driver_infrastructure.Monitor, error) {
+	// Cache hits stay off initializationLock so they don't serialize; some
+	// callers look up their monitor on every network-bound method call.
+	if monitor, exists := c.getAndExtendExpiration(key); exists {
+		return monitor, nil
+	}
+
 	c.initializationLock.Lock()
-	if existingItem, exists := c.cache.Get(key); exists && existingItem != nil {
-		existingItem.expiresAt.Store(time.Now().Add(c.settings.ExpirationTimeout).UnixNano())
+	// Re-check under the lock: an initialization that completed after the
+	// lock-free read would otherwise be duplicated.
+	if monitor, exists := c.getAndExtendExpiration(key); exists {
 		c.initializationLock.Unlock()
-		return existingItem.monitor, nil
+		return monitor, nil
 	}
 
 	if initialization, exists := c.monitorInitializations[key]; exists {

--- a/awssql/services/monitor.go
+++ b/awssql/services/monitor.go
@@ -84,6 +84,7 @@ func (c *cacheContainer) runIfAbsent(
 	c.initializationLock.Unlock()
 
 	monitor, err := monitorSupplier()
+	c.initializationLock.Lock()
 	if err == nil {
 		item := &monitorItem{
 			monitor:         monitor,
@@ -95,7 +96,6 @@ func (c *cacheContainer) runIfAbsent(
 		monitor.Start()
 	}
 
-	c.initializationLock.Lock()
 	initialization.monitor = monitor
 	initialization.err = err
 	delete(c.monitorInitializations, key)
@@ -295,6 +295,8 @@ func (m *MonitorManager) checkMonitors() {
 	m.monitorCaches.ForEach(func(_ string, container *cacheContainer) {
 		settings := container.settings
 
+		container.initializationLock.Lock()
+
 		// Remove and stop monitors that are stopped or expired
 		stopped := container.cache.RemoveIf(func(_ any, item *monitorItem) bool {
 			if item == nil {
@@ -305,9 +307,6 @@ func (m *MonitorManager) checkMonitors() {
 			}
 			return now.After(time.Unix(0, item.expiresAt.Load())) && item.monitor.CanDispose()
 		})
-		for _, entry := range stopped {
-			entry.Value.monitor.Stop()
-		}
 
 		// Remove and handle monitors in error state or stuck
 		errored := container.cache.RemoveIf(func(_ any, item *monitorItem) bool {
@@ -320,6 +319,12 @@ func (m *MonitorManager) checkMonitors() {
 			lastActivity := time.Unix(0, item.monitor.GetLastActivityTimestampNanos())
 			return now.Sub(lastActivity) > settings.InactiveTimeout
 		})
+
+		container.initializationLock.Unlock()
+
+		for _, entry := range stopped {
+			entry.Value.monitor.Stop()
+		}
 		for _, entry := range errored {
 			m.handleMonitorError(container, entry.Key, entry.Value)
 		}


### PR DESCRIPTION
### Summary

Coalesce concurrent `MonitorManager` initialization by monitor key so same-key callers receive one shared monitor instead of starting untracked duplicates.

Closes #502.

### Description

`RunIfAbsent` previously performed its cache read, monitor construction, `PutIfAbsent`, and `Start` as separate operations. Concurrent callers could all miss an empty cache and construct private monitors. The cache retained only one monitor, but every caller still started the monitor it constructed.

Before:

```text
100 connection requests
  ├─ all check for topology monitor → absent
  ├─ all create their own monitor
  ├─ map retains only one
  └─ all 100 monitors are nevertheless started
```

After:

```text
100 connection requests
  ├─ first request initializes the topology monitor
  ├─ other 99 wait for that same-key initialization
  ├─ map retains the one initialized monitor
  └─ all 100 requests receive the same monitor
```

The change tracks in-flight initialization per monitor key:

- only the first same-key caller invokes the initializer and starts the monitor;
- concurrent same-key callers wait for and receive the same result;
- different keys can still initialize concurrently;
- failed initialization is not cached, allowing a later call to retry;
- monitor recreation after an error uses the same coalescing path.

This removes duplicate topology queries, background goroutines, and monitoring connections created by a cold concurrent burst. It does not share physical SQL connections or connection-scoped plugin, session, or transaction state.

### Validation

- `go test ./...` from `awssql`
- `go test ./test/services -count=1` from `.test`
- `go test -race ./test/services -run 'TestMonitorManagerRunIfAbsent' -count=20` from `.test`
- `golangci-lint v2.11.3` for `awssql` and `.test`: 0 issues

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
