### PR TITLE
fix(error-handler): match PostgreSQL SQLSTATE by class prefix

### DIFF
--- a/.test/test/pgx_driver_dialect_test.go
+++ b/.test/test/pgx_driver_dialect_test.go
@@ -109,3 +109,13 @@ func TestPgxErrorHandler_TypedTransportSentinels(t *testing.T) {
 	assert.True(t, h.IsNetworkError(fmt.Errorf("write tcp: %w", syscall.EPIPE)))
 	assert.True(t, h.IsNetworkError(fmt.Errorf("reading message: %w", io.ErrUnexpectedEOF)))
 }
+
+func TestPgxErrorHandler_SqlStatePrefixMatching(t *testing.T) {
+	h := &pgx_driver.PgxErrorHandler{}
+	for _, code := range []string{"08006", "08003", "08000", "08001", "08004", "58030", "53300", "53000", "F0000", "57P01", "57P03"} {
+		assert.True(t, h.IsNetworkError(&pgconn.PgError{Code: code}), "expected network error for %s", code)
+	}
+	for _, code := range []string{"57014", "40001", "40P01", "XX000", "25006"} {
+		assert.False(t, h.IsNetworkError(&pgconn.PgError{Code: code}), "expected NOT network error for %s", code)
+	}
+}

--- a/bun-pg-driver/bun_error_handler.go
+++ b/bun-pg-driver/bun_error_handler.go
@@ -69,7 +69,9 @@ func (h *BunPgErrorHandler) IsNetworkError(err error) bool {
 	}
 
 	sqlState := h.getSQLStateFromError(err)
-	if sqlState != "" && slices.Contains(NetworkErrors, sqlState) {
+	if sqlState != "" && slices.ContainsFunc(NetworkErrors, func(prefix string) bool {
+		return strings.HasPrefix(sqlState, prefix)
+	}) {
 		return true
 	}
 

--- a/bun-pg-driver/bun_error_handler_test.go
+++ b/bun-pg-driver/bun_error_handler_test.go
@@ -94,3 +94,9 @@ func TestGetSQLState(t *testing.T) {
 		var _ pgdriver.Error
 	})
 }
+
+func TestBunPgErrorHandler_NetworkErrorsList(t *testing.T) {
+	assert.Contains(t, NetworkErrors, "53")
+	assert.Contains(t, NetworkErrors, "08")
+	assert.NotContains(t, AccessErrors, "08004")
+}

--- a/pgx-driver/pgx_error_handler.go
+++ b/pgx-driver/pgx_error_handler.go
@@ -69,8 +69,9 @@ func (p *PgxErrorHandler) IsNetworkError(err error) bool {
 	}
 
 	sqlState := p.getSQLStateFromError(err)
-
-	if sqlState != "" && slices.Contains(NetworkErrors, sqlState) {
+	if sqlState != "" && slices.ContainsFunc(NetworkErrors, func(prefix string) bool {
+		return strings.HasPrefix(sqlState, prefix)
+	}) {
 		return true
 	}
 


### PR DESCRIPTION
### Summary

Match PostgreSQL SQLSTATE by class prefix instead of exact equality, so connection-class errors are actually detected. Follows up on the prefix note in #492.

### Description

`IsNetworkError` compared the full 5-char SQLSTATE for exact equality against the 2-char class entries in `NetworkErrors` (`08`, `58`, `F0`, `53`), which can never match. Only the full codes `57P01/02/03` ever fired, so the entire `08xxx` connection-exception class was missed.

It now matches by class prefix (`strings.HasPrefix`), consistent with the MySQL handler. The set of network-error classes is unchanged.

### Validation

- [x] `go build ./...` (pgx-driver, bun-pg-driver)
- [x] `go test ./...` (bun-pg-driver)
- [x] `go test ./test/ -run 'PgxErrorHandler'` (.test)

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
