### PR TITLE
fix(error-handler): stop treating net.ErrClosed (local close) as a network error

### DIFF
--- a/.test/test/pgx_driver_dialect_test.go
+++ b/.test/test/pgx_driver_dialect_test.go
@@ -21,6 +21,7 @@ import (
 	"database/sql/driver"
 	"errors"
 	"fmt"
+	"net"
 	"regexp"
 	"strings"
 	"testing"
@@ -92,4 +93,10 @@ func TestPgxErrorHandler_CallerCancellationAndStaleConn(t *testing.T) {
 		assert.False(t, errorHandler.IsNetworkError(driver.ErrBadConn))
 		assert.False(t, errorHandler.IsNetworkError(fmt.Errorf("wrapped: %w", driver.ErrBadConn)))
 	})
+}
+
+func TestPgxErrorHandler_LocalCloseNotNetwork(t *testing.T) {
+	h := &pgx_driver.PgxErrorHandler{}
+	assert.False(t, h.IsNetworkError(net.ErrClosed))
+	assert.False(t, h.IsNetworkError(fmt.Errorf("read tcp: %w", net.ErrClosed)))
 }

--- a/bun-pg-driver/bun_error_handler.go
+++ b/bun-pg-driver/bun_error_handler.go
@@ -44,7 +44,6 @@ var NetworkErrors = []string{
 
 var PgNetworkErrorMessages = []string{
 	"unexpected EOF",
-	"use of closed network connection",
 	"broken pipe",
 }
 

--- a/bun-pg-driver/bun_error_handler_test.go
+++ b/bun-pg-driver/bun_error_handler_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"database/sql/driver"
 	"fmt"
+	"net"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,8 +32,12 @@ func TestBunPgErrorHandler_IsNetworkError(t *testing.T) {
 
 	t.Run("network error message patterns", func(t *testing.T) {
 		assert.True(t, h.IsNetworkError(fmt.Errorf("unexpected EOF")))
-		assert.True(t, h.IsNetworkError(fmt.Errorf("read: use of closed network connection")))
 		assert.True(t, h.IsNetworkError(fmt.Errorf("write: broken pipe")))
+	})
+
+	t.Run("net.ErrClosed (local close) is not a network error", func(t *testing.T) {
+		assert.False(t, h.IsNetworkError(net.ErrClosed))
+		assert.False(t, h.IsNetworkError(fmt.Errorf("read: use of closed network connection")))
 	})
 
 	t.Run("non-network errors", func(t *testing.T) {

--- a/pgx-driver/pgx_error_handler.go
+++ b/pgx-driver/pgx_error_handler.go
@@ -44,7 +44,6 @@ var NetworkErrors = []string{
 
 var PgNetworkErrorMessages = []string{
 	"unexpected EOF",
-	"use of closed network connection",
 	"broken pipe",
 }
 


### PR DESCRIPTION
### Summary

Stop treating `net.ErrClosed` ("use of closed network connection") as a network error in the pgx and bun-pg handlers.

### Description

`net.ErrClosed` is returned only when the local side already closed the socket: context-cancel teardown, pool eviction, or the wrapper's own failover teardown. It is never a peer or host fault. Classifying it as a network error let a failover teardown surface as a network failure on an in-flight query, triggering a second failover and marking a healthy host unavailable.

Removed it from `PgNetworkErrorMessages`. Real peer faults still trigger failover via SQLSTATE `08xxx`, `"unexpected EOF"`, and `"broken pipe"`. No sibling wrapper (JDBC, Python, Node, .NET) treats a locally closed connection as failover.

### Validation

- [x] `go test ./...` (bun-pg-driver)
- [x] `go test ./test/ -run 'PgxErrorHandler'` (.test)

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

