### PR TITLE
feat(error-handler): classify peer transport faults via typed net sentinels (ECONNRESET/EPIPE/ErrUnexpectedEOF)

### DIFF
--- a/.test/test/mysql_driver_dialect_test.go
+++ b/.test/test/mysql_driver_dialect_test.go
@@ -21,6 +21,8 @@ import (
 	"database/sql/driver"
 	"errors"
 	"fmt"
+	"io"
+	"syscall"
 	"testing"
 
 	"github.com/aws/aws-advanced-go-wrapper/awssql/v2/property_util"
@@ -136,6 +138,12 @@ func TestMySQLErrorHandler_IsNetworkError(t *testing.T) {
 		// on non-cancellation I/O failures — a genuine network failure signal.
 		assert.True(t, handler.IsNetworkError(mysql.ErrInvalidConn))
 		assert.True(t, handler.IsNetworkError(fmt.Errorf("wrapped: %w", mysql.ErrInvalidConn)))
+	})
+
+	t.Run("typed transport sentinels are network errors", func(t *testing.T) {
+		assert.True(t, handler.IsNetworkError(fmt.Errorf("read tcp: %w", syscall.ECONNRESET)))
+		assert.True(t, handler.IsNetworkError(fmt.Errorf("write tcp: %w", syscall.EPIPE)))
+		assert.True(t, handler.IsNetworkError(fmt.Errorf("reading: %w", io.ErrUnexpectedEOF)))
 	})
 
 	t.Run("non-network errors", func(t *testing.T) {

--- a/.test/test/pgx_driver_dialect_test.go
+++ b/.test/test/pgx_driver_dialect_test.go
@@ -21,9 +21,11 @@ import (
 	"database/sql/driver"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"regexp"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/aws/aws-advanced-go-wrapper/awssql/v2/property_util"
@@ -99,4 +101,11 @@ func TestPgxErrorHandler_LocalCloseNotNetwork(t *testing.T) {
 	h := &pgx_driver.PgxErrorHandler{}
 	assert.False(t, h.IsNetworkError(net.ErrClosed))
 	assert.False(t, h.IsNetworkError(fmt.Errorf("read tcp: %w", net.ErrClosed)))
+}
+
+func TestPgxErrorHandler_TypedTransportSentinels(t *testing.T) {
+	h := &pgx_driver.PgxErrorHandler{}
+	assert.True(t, h.IsNetworkError(fmt.Errorf("read tcp 10.0.0.1:5432->10.0.0.2:5432: %w", syscall.ECONNRESET)))
+	assert.True(t, h.IsNetworkError(fmt.Errorf("write tcp: %w", syscall.EPIPE)))
+	assert.True(t, h.IsNetworkError(fmt.Errorf("reading message: %w", io.ErrUnexpectedEOF)))
 }

--- a/bun-pg-driver/bun_error_handler.go
+++ b/bun-pg-driver/bun_error_handler.go
@@ -20,8 +20,10 @@ import (
 	"context"
 	"database/sql/driver"
 	"errors"
+	"io"
 	"slices"
 	"strings"
+	"syscall"
 
 	"github.com/uptrace/bun/driver/pgdriver"
 )
@@ -59,6 +61,11 @@ func (h *BunPgErrorHandler) IsNetworkError(err error) bool {
 	// server/network faults surface as SQLSTATE 08xxx/57P01 or raw I/O errors.
 	if errors.Is(err, driver.ErrBadConn) {
 		return false
+	}
+
+	// Typed transport faults; substrings below are a fallback.
+	if errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.EPIPE) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
 	}
 
 	sqlState := h.getSQLStateFromError(err)

--- a/bun-pg-driver/bun_error_handler_test.go
+++ b/bun-pg-driver/bun_error_handler_test.go
@@ -20,7 +20,9 @@ import (
 	"context"
 	"database/sql/driver"
 	"fmt"
+	"io"
 	"net"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -56,6 +58,13 @@ func TestBunPgErrorHandler_IsNetworkError(t *testing.T) {
 		assert.False(t, h.IsNetworkError(driver.ErrBadConn))
 		assert.False(t, h.IsNetworkError(fmt.Errorf("wrapped: %w", driver.ErrBadConn)))
 	})
+}
+
+func TestBunPgErrorHandler_TypedTransportSentinels(t *testing.T) {
+	h := &BunPgErrorHandler{}
+	assert.True(t, h.IsNetworkError(fmt.Errorf("read tcp: %w", syscall.ECONNRESET)))
+	assert.True(t, h.IsNetworkError(fmt.Errorf("write tcp: %w", syscall.EPIPE)))
+	assert.True(t, h.IsNetworkError(fmt.Errorf("reading: %w", io.ErrUnexpectedEOF)))
 }
 
 func TestBunPgErrorHandler_IsLoginError(t *testing.T) {

--- a/mysql-driver/mysql_error_handler.go
+++ b/mysql-driver/mysql_error_handler.go
@@ -20,7 +20,9 @@ import (
 	"context"
 	"database/sql/driver"
 	"errors"
+	"io"
 	"strings"
+	"syscall"
 
 	"github.com/go-sql-driver/mysql"
 )
@@ -48,6 +50,11 @@ func (m MySQLErrorHandler) IsNetworkError(err error) bool {
 	// readPacket/writePacket when the underlying net.Conn fails mid-query
 	// (after a non-cancellation I/O error); it IS a genuine network failure.
 	if errors.Is(err, mysql.ErrInvalidConn) {
+		return true
+	}
+
+	// Typed transport faults; substrings below are a fallback.
+	if errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.EPIPE) || errors.Is(err, io.ErrUnexpectedEOF) {
 		return true
 	}
 

--- a/pgx-driver/pgx_error_handler.go
+++ b/pgx-driver/pgx_error_handler.go
@@ -20,8 +20,10 @@ import (
 	"context"
 	"database/sql/driver"
 	"errors"
+	"io"
 	"slices"
 	"strings"
+	"syscall"
 
 	"github.com/jackc/pgx/v5/pgconn"
 )
@@ -59,6 +61,11 @@ func (p *PgxErrorHandler) IsNetworkError(err error) bool {
 	// cached conn and retries on a fresh one. Not a network fault.
 	if errors.Is(err, driver.ErrBadConn) {
 		return false
+	}
+
+	// Typed transport faults; substrings below are a fallback.
+	if errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.EPIPE) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
 	}
 
 	sqlState := p.getSQLStateFromError(err)


### PR DESCRIPTION
### Summary

Classify peer transport faults via typed `errors.Is` sentinels (`syscall.ECONNRESET`, `syscall.EPIPE`, `io.ErrUnexpectedEOF`) in all three handlers. Fixes a missed failover: connection-reset-by-peer, the most common Aurora failover signal, was not matched by the PG handlers.

### Description

pgx and go-sql-driver/mysql surface a peer reset as `syscall.ECONNRESET` wrapped in `*net.OpError`, which the PG substring lists did not cover. Typed matching also avoids false positives from server messages that quote these words and from locale drift.

The change is additive; the existing substring lists stay as a fallback (Windows `WSAE*` codes have different `Errno` values). A full substring-to-typed migration with build tags is left as a follow-up.

Every sibling wrapper classifies peer reset: JDBC and Python via SQLSTATE `08006`, .NET via `SocketException`, Node via the `"read ECONNRESET"` string.

### Validation

- [x] `go build ./...` (pgx-driver, mysql-driver)
- [x] `go test ./...` (bun-pg-driver)
- [x] `go test ./test/ -run 'ErrorHandler'` (.test)

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

