### PR TITLE
fix(error-handler): exclude MySQL SQLSTATE 08004 (server rejected) from network errors

### DIFF
--- a/.test/test/mysql_driver_dialect_test.go
+++ b/.test/test/mysql_driver_dialect_test.go
@@ -109,6 +109,16 @@ func TestMySQLErrorHandler_IsNetworkError(t *testing.T) {
 		assert.True(t, handler.IsNetworkError(err))
 	})
 
+	t.Run("SQLSTATE 08004 (server rejected) is NOT a network error", func(t *testing.T) {
+		err := &mysql.MySQLError{SQLState: [5]byte{'0', '8', '0', '0', '4'}, Message: "rejected"}
+		assert.False(t, handler.IsNetworkError(err))
+	})
+
+	t.Run("other 08 class codes remain network errors", func(t *testing.T) {
+		err := &mysql.MySQLError{SQLState: [5]byte{'0', '8', 'S', '0', '1'}, Message: "link failure"}
+		assert.True(t, handler.IsNetworkError(err))
+	})
+
 	t.Run("caller cancellation is not a network error", func(t *testing.T) {
 		assert.False(t, handler.IsNetworkError(context.Canceled))
 		assert.False(t, handler.IsNetworkError(fmt.Errorf("query aborted: %w", context.Canceled)))

--- a/mysql-driver/mysql_error_handler.go
+++ b/mysql-driver/mysql_error_handler.go
@@ -52,7 +52,8 @@ func (m MySQLErrorHandler) IsNetworkError(err error) bool {
 	}
 
 	sqlState := m.getSQLStateFromError(err)
-	if sqlState != "" && string(sqlState[0:2]) == "08" {
+	// 08004 (server rejected) is not a network fault.
+	if sqlState != "" && sqlState[0:2] == "08" && sqlState != "08004" {
 		return true
 	}
 


### PR DESCRIPTION
### Summary

Exclude MySQL SQLSTATE `08004` from `IsNetworkError`, so a server-side connection rejection no longer triggers a spurious failover.

### Description

`08004` ("server rejected the connection") is a deliberate rejection at establishment (auth, connection limits, startup), not a transient network drop. Failing over cannot resolve it and hides the real cause. The check now matches the `08` class except `08004`; other `08` codes (e.g. `08S01`) still trigger failover.

Follows the JDBC MySQL handler, which matches the `08` class except `08004`.

### Validation

- [x] `go build ./...` (mysql-driver)
- [x] `go test ./test/ -run 'MySQLErrorHandler'` (.test)

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

