### PR TITLE
feat(failover): fail over on read-only connection error in strict-writer mode

### DIFF
--- a/.test/test/mock_implementations.go
+++ b/.test/test/mock_implementations.go
@@ -537,6 +537,10 @@ func (p *MockPluginService) IsLoginError(_ error) bool {
 	return false
 }
 
+func (p *MockPluginService) IsReadOnlyError(_ error) bool {
+	return false
+}
+
 func (p *MockPluginService) GetTelemetryContext() context.Context {
 	return p.PluginManager.GetTelemetryContext()
 }

--- a/.test/test/mocks/awssql/driver_infrastructure/mock_driver_dialect.go
+++ b/.test/test/mocks/awssql/driver_infrastructure/mock_driver_dialect.go
@@ -178,6 +178,20 @@ func (mr *MockDriverDialectMockRecorder) IsNetworkError(arg0 interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsNetworkError", reflect.TypeOf((*MockDriverDialect)(nil).IsNetworkError), arg0)
 }
 
+// IsReadOnlyError mocks base method.
+func (m *MockDriverDialect) IsReadOnlyError(arg0 error) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsReadOnlyError", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsReadOnlyError indicates an expected call of IsReadOnlyError.
+func (mr *MockDriverDialectMockRecorder) IsReadOnlyError(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsReadOnlyError", reflect.TypeOf((*MockDriverDialect)(nil).IsReadOnlyError), arg0)
+}
+
 // PrepareDsn mocks base method.
 func (m *MockDriverDialect) PrepareDsn(arg0 map[string]string, arg1 *host_info_util.HostInfo) string {
 	m.ctrl.T.Helper()

--- a/.test/test/mocks/awssql/driver_infrastructure/mock_plugin_helpers.go
+++ b/.test/test/mocks/awssql/driver_infrastructure/mock_plugin_helpers.go
@@ -614,6 +614,20 @@ func (mr *MockPluginServiceMockRecorder) IsNetworkError(arg0 interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsNetworkError", reflect.TypeOf((*MockPluginService)(nil).IsNetworkError), arg0)
 }
 
+// IsReadOnlyError mocks base method.
+func (m *MockPluginService) IsReadOnlyError(arg0 error) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsReadOnlyError", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsReadOnlyError indicates an expected call of IsReadOnlyError.
+func (mr *MockPluginServiceMockRecorder) IsReadOnlyError(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsReadOnlyError", reflect.TypeOf((*MockPluginService)(nil).IsReadOnlyError), arg0)
+}
+
 // IsPluginInUse mocks base method.
 func (m *MockPluginService) IsPluginInUse(arg0 string) bool {
 	m.ctrl.T.Helper()

--- a/.test/test/mysql_driver_dialect_test.go
+++ b/.test/test/mysql_driver_dialect_test.go
@@ -165,3 +165,11 @@ func TestPrepareDsnWithoutHost(t *testing.T) {
 	dsn := driverDialect.PrepareDsn(properties, nil)
 	assert.Equal(t, "user:password@tcp/dbName", dsn)
 }
+
+func TestMySQLErrorHandler_IsReadOnlyError(t *testing.T) {
+	handler := mysql_driver.MySQLErrorHandler{}
+	assert.True(t, handler.IsReadOnlyError(&mysql.MySQLError{Number: 1290, Message: "read-only"}))
+	assert.True(t, handler.IsReadOnlyError(&mysql.MySQLError{Number: 1836, Message: "read-only mode"}))
+	assert.False(t, handler.IsReadOnlyError(&mysql.MySQLError{Number: 1146, Message: "table missing"}))
+	assert.False(t, handler.IsNetworkError(&mysql.MySQLError{Number: 1290, Message: "read-only"}))
+}

--- a/.test/test/mysql_driver_dialect_test.go
+++ b/.test/test/mysql_driver_dialect_test.go
@@ -173,3 +173,10 @@ func TestMySQLErrorHandler_IsReadOnlyError(t *testing.T) {
 	assert.False(t, handler.IsReadOnlyError(&mysql.MySQLError{Number: 1146, Message: "table missing"}))
 	assert.False(t, handler.IsNetworkError(&mysql.MySQLError{Number: 1290, Message: "read-only"}))
 }
+
+func TestMySQLDriverDialect_IsReadOnlyError(t *testing.T) {
+	d := mysql_driver.NewMySQLDriverDialect()
+	assert.True(t, d.IsReadOnlyError(&mysql.MySQLError{Number: 1290}))
+	assert.False(t, d.IsReadOnlyError(&mysql.MySQLError{Number: 1146}))
+	assert.False(t, d.IsNetworkError(&mysql.MySQLError{Number: 1290}))
+}

--- a/.test/test/pgx_driver_dialect_test.go
+++ b/.test/test/pgx_driver_dialect_test.go
@@ -127,3 +127,10 @@ func TestPgxErrorHandler_IsReadOnlyError(t *testing.T) {
 	assert.False(t, h.IsReadOnlyError(fmt.Errorf("some error")))
 	assert.False(t, h.IsNetworkError(&pgconn.PgError{Code: "25006"}))
 }
+
+func TestPgxDriverDialect_IsReadOnlyError(t *testing.T) {
+	d := pgx_driver.NewPgxDriverDialect()
+	assert.True(t, d.IsReadOnlyError(&pgconn.PgError{Code: "25006"}))
+	assert.False(t, d.IsReadOnlyError(&pgconn.PgError{Code: "08006"}))
+	assert.False(t, d.IsNetworkError(&pgconn.PgError{Code: "25006"}))
+}

--- a/.test/test/pgx_driver_dialect_test.go
+++ b/.test/test/pgx_driver_dialect_test.go
@@ -119,3 +119,11 @@ func TestPgxErrorHandler_SqlStatePrefixMatching(t *testing.T) {
 		assert.False(t, h.IsNetworkError(&pgconn.PgError{Code: code}), "expected NOT network error for %s", code)
 	}
 }
+
+func TestPgxErrorHandler_IsReadOnlyError(t *testing.T) {
+	h := &pgx_driver.PgxErrorHandler{}
+	assert.True(t, h.IsReadOnlyError(&pgconn.PgError{Code: "25006"}))
+	assert.False(t, h.IsReadOnlyError(&pgconn.PgError{Code: "08006"}))
+	assert.False(t, h.IsReadOnlyError(fmt.Errorf("some error")))
+	assert.False(t, h.IsNetworkError(&pgconn.PgError{Code: "25006"}))
+}

--- a/awssql/driver_infrastructure/driver_dialect.go
+++ b/awssql/driver_infrastructure/driver_dialect.go
@@ -29,6 +29,7 @@ type DriverDialect interface {
 	PrepareDsn(properties map[string]string, info *host_info_util.HostInfo) string
 	IsNetworkError(err error) bool
 	IsLoginError(err error) bool
+	IsReadOnlyError(err error) bool
 	IsClosed(conn driver.Conn) bool
 	IsDriverRegistered(drivers map[string]driver.Driver) bool
 	RegisterDriver()

--- a/awssql/driver_infrastructure/plugin_helpers.go
+++ b/awssql/driver_infrastructure/plugin_helpers.go
@@ -82,6 +82,7 @@ type PluginService interface {
 	GetProperties() *utils.RWMap[string, string]
 	IsNetworkError(err error) bool
 	IsLoginError(err error) bool
+	IsReadOnlyError(err error) bool
 	GetTelemetryContext() context.Context
 	GetTelemetryFactory() telemetry.TelemetryFactory
 	SetTelemetryContext(ctx context.Context)

--- a/awssql/error_util/error_handler.go
+++ b/awssql/error_util/error_handler.go
@@ -19,4 +19,5 @@ package error_util
 type ErrorHandler interface {
 	IsNetworkError(err error) bool
 	IsLoginError(err error) bool
+	IsReadOnlyError(err error) bool
 }

--- a/awssql/plugin_helpers/partial_plugin_service.go
+++ b/awssql/plugin_helpers/partial_plugin_service.go
@@ -252,8 +252,9 @@ func (p *PartialPluginService) GetConnectionProvider() driver_infrastructure.Con
 func (p *PartialPluginService) GetProperties() *utils.RWMap[string, string] {
 	panic("Method not implemented.")
 }
-func (p *PartialPluginService) IsNetworkError(err error) bool { panic("Method not implemented.") }
-func (p *PartialPluginService) IsLoginError(err error) bool   { panic("Method not implemented.") }
+func (p *PartialPluginService) IsNetworkError(err error) bool  { panic("Method not implemented.") }
+func (p *PartialPluginService) IsLoginError(err error) bool    { panic("Method not implemented.") }
+func (p *PartialPluginService) IsReadOnlyError(err error) bool { panic("Method not implemented.") }
 func (p *PartialPluginService) GetTelemetryFactory() telemetry.TelemetryFactory {
 	panic("Method not implemented.")
 }

--- a/awssql/plugin_helpers/plugin_service.go
+++ b/awssql/plugin_helpers/plugin_service.go
@@ -587,6 +587,10 @@ func (p *PluginServiceImpl) IsLoginError(err error) bool {
 	return p.driverDialect.IsLoginError(err)
 }
 
+func (p *PluginServiceImpl) IsReadOnlyError(err error) bool {
+	return p.driverDialect.IsReadOnlyError(err)
+}
+
 func (p *PluginServiceImpl) UpdateState(sql string, methodArgs ...any) {
 	query := utils.GetQueryFromSqlOrMethodArgs(sql, methodArgs...)
 

--- a/awssql/plugins/failover_plugin.go
+++ b/awssql/plugins/failover_plugin.go
@@ -597,7 +597,11 @@ func (p *FailoverPlugin) shouldErrorTriggerConnectionSwitch(err error) bool {
 		return false
 	}
 
-	return p.servicesContainer.GetPluginService().IsNetworkError(err)
+	pluginService := p.servicesContainer.GetPluginService()
+	if pluginService.IsNetworkError(err) {
+		return true
+	}
+	return p.FailoverMode == MODE_STRICT_WRITER && pluginService.IsReadOnlyError(err)
 }
 
 func (p *FailoverPlugin) createConnectionForHost(hostInfo *host_info_util.HostInfo) (driver.Conn, error) {

--- a/bun-pg-driver/bun_driver_dialect.go
+++ b/bun-pg-driver/bun_driver_dialect.go
@@ -71,6 +71,10 @@ func (d BunPgDriverDialect) IsLoginError(err error) bool {
 	return d.errorHandler.IsLoginError(err)
 }
 
+func (d BunPgDriverDialect) IsReadOnlyError(err error) bool {
+	return d.errorHandler.IsReadOnlyError(err)
+}
+
 func (d BunPgDriverDialect) IsClosed(conn driver.Conn) bool {
 	if validator, ok := conn.(driver.Validator); ok {
 		return !validator.IsValid()

--- a/bun-pg-driver/bun_error_handler.go
+++ b/bun-pg-driver/bun_error_handler.go
@@ -49,7 +49,15 @@ var PgNetworkErrorMessages = []string{
 	"broken pipe",
 }
 
+// PgReadOnlyErrorState is the SQLSTATE for a write to a read-only connection.
+const PgReadOnlyErrorState = "25006"
+
 type BunPgErrorHandler struct{}
+
+// IsReadOnlyError reports whether err is a write to a read-only connection.
+func (h *BunPgErrorHandler) IsReadOnlyError(err error) bool {
+	return h.getSQLStateFromError(err) == PgReadOnlyErrorState
+}
 
 func (h *BunPgErrorHandler) IsNetworkError(err error) bool {
 	// Caller-initiated cancellation / deadline is not a DB network failure.

--- a/bun-pg-driver/bun_error_handler_test.go
+++ b/bun-pg-driver/bun_error_handler_test.go
@@ -100,3 +100,7 @@ func TestBunPgErrorHandler_NetworkErrorsList(t *testing.T) {
 	assert.Contains(t, NetworkErrors, "08")
 	assert.NotContains(t, AccessErrors, "08004")
 }
+
+func TestBunPgErrorHandler_ReadOnlyConst(t *testing.T) {
+	assert.Equal(t, "25006", PgReadOnlyErrorState)
+}

--- a/mysql-driver/mysql_driver_dialect.go
+++ b/mysql-driver/mysql_driver_dialect.go
@@ -63,6 +63,10 @@ func (m MySQLDriverDialect) IsLoginError(err error) bool {
 	return m.errorHandler.IsLoginError(err)
 }
 
+func (m MySQLDriverDialect) IsReadOnlyError(err error) bool {
+	return m.errorHandler.IsReadOnlyError(err)
+}
+
 func (m MySQLDriverDialect) IsClosed(conn driver.Conn) bool {
 	validator, ok := conn.(driver.Validator)
 	if ok {

--- a/mysql-driver/mysql_error_handler.go
+++ b/mysql-driver/mysql_error_handler.go
@@ -21,6 +21,7 @@ import (
 	"database/sql/driver"
 	"errors"
 	"io"
+	"slices"
 	"strings"
 	"syscall"
 
@@ -33,7 +34,23 @@ var MySqlNetworkErrorMessages = []string{
 	"broken pipe",
 }
 
+// MySqlReadOnlyErrorCodes are error numbers for a write to a read-only connection.
+var MySqlReadOnlyErrorCodes = []uint16{
+	1290, // running with --read-only
+	1836, // read-only mode
+	1792, // read-only transaction
+}
+
 type MySQLErrorHandler struct {
+}
+
+// IsReadOnlyError reports whether err is a write to a read-only connection.
+func (m MySQLErrorHandler) IsReadOnlyError(err error) bool {
+	var mysqlErr *mysql.MySQLError
+	if errors.As(err, &mysqlErr) {
+		return slices.Contains(MySqlReadOnlyErrorCodes, mysqlErr.Number)
+	}
+	return false
 }
 
 func (m MySQLErrorHandler) IsNetworkError(err error) bool {

--- a/pgx-driver/pgx_driver_dialect.go
+++ b/pgx-driver/pgx_driver_dialect.go
@@ -72,6 +72,10 @@ func (p PgxDriverDialect) IsLoginError(err error) bool {
 	return p.errorHandler.IsLoginError(err)
 }
 
+func (p PgxDriverDialect) IsReadOnlyError(err error) bool {
+	return p.errorHandler.IsReadOnlyError(err)
+}
+
 func (p PgxDriverDialect) IsClosed(conn driver.Conn) bool {
 	// If pgx implements driver.Validator, use this
 	validator, ok := conn.(driver.Validator)

--- a/pgx-driver/pgx_error_handler.go
+++ b/pgx-driver/pgx_error_handler.go
@@ -49,7 +49,15 @@ var PgNetworkErrorMessages = []string{
 	"broken pipe",
 }
 
+// PgReadOnlyErrorState is the SQLSTATE for a write to a read-only connection.
+const PgReadOnlyErrorState = "25006"
+
 type PgxErrorHandler struct {
+}
+
+// IsReadOnlyError reports whether err is a write to a read-only connection.
+func (p *PgxErrorHandler) IsReadOnlyError(err error) bool {
+	return p.getSQLStateFromError(err) == PgReadOnlyErrorState
 }
 
 func (p *PgxErrorHandler) IsNetworkError(err error) bool {


### PR DESCRIPTION
### Summary

Fail over to the new writer when a write hits a read-only (demoted) connection in strict-writer mode. Adds `IsReadOnlyError` detection (PostgreSQL SQLSTATE `25006`, MySQL error numbers `1290`/`1836`/`1792`) and wires it into the failover plugin.

### Description

`25006` (read_only_sql_transaction) is raised when a write is attempted on a connection that is now read-only, e.g. a former writer demoted to a reader after a failover. The host is healthy, so this is a routing signal, not a network error.

- `IsReadOnlyError(err) bool` is added to the concrete handlers (pgx, bun-pg, mysql) and to the `ErrorHandler`, `DriverDialect`, and `PluginService` interfaces, with delegation mirroring `IsNetworkError`.
- `shouldErrorTriggerConnectionSwitch` now also triggers when `FailoverMode == MODE_STRICT_WRITER && IsReadOnlyError(err)`, so the wrapper reconnects to the new writer. Other failover modes are unaffected, and a read-only error is never treated as a network error.

Matches the JDBC wrapper's read-only failover (strict-writer only).

### Validation

- [x] `go build ./...` (awssql, pgx-driver, mysql-driver, bun-pg-driver, .test)
- [x] `go test ./test/ -run 'ReadOnly|DriverDialect|ErrorHandler|Failover'` (.test)
- [x] `go test ./...` (bun-pg-driver)

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
