### PR TITLE
fix: ErrConnClosed and ErrClosed handling

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-    paths-ignore: 
+    paths-ignore:
       - "**/*.md"
       - "docs/**"
 

--- a/.test/test/efm_test.go
+++ b/.test/test/efm_test.go
@@ -19,6 +19,8 @@ package test
 import (
 	"database/sql/driver"
 	"errors"
+	"fmt"
+	"net"
 	"strings"
 	"testing"
 	"time"
@@ -27,6 +29,7 @@ import (
 	mock_driver_infrastructure "github.com/aws/aws-advanced-go-wrapper/.test/test/mocks/awssql/driver_infrastructure"
 	awssql "github.com/aws/aws-advanced-go-wrapper/awssql/v2/driver"
 	"github.com/aws/aws-advanced-go-wrapper/awssql/v2/driver_infrastructure"
+	"github.com/aws/aws-advanced-go-wrapper/awssql/v2/error_util"
 	"github.com/aws/aws-advanced-go-wrapper/awssql/v2/host_info_util"
 	"github.com/aws/aws-advanced-go-wrapper/awssql/v2/plugin_helpers"
 	"github.com/aws/aws-advanced-go-wrapper/awssql/v2/plugins/efm"
@@ -95,6 +98,58 @@ func TestMonitorConnectionState(t *testing.T) {
 	state.SetHostUnhealthy(false)
 	// Not unhealthy and no conn, no need to abort.
 	assert.False(t, state.ShouldAbort())
+}
+
+// IsHostUnhealthy must survive SetInactive, unlike ShouldAbort. The monitor calls
+// SetInactive before closing the connection, so by the time the aborted call
+// returns and the plugin needs to know why it failed, ShouldAbort is already
+// false. This is what lets the plugin tell a monitor-initiated abort apart from
+// an unrelated error rather than guessing from the driver's transport error.
+func TestMonitorConnectionStateIsHostUnhealthySurvivesSetInactive(t *testing.T) {
+	var conn driver.Conn = &MockDriverConn{}
+	state := efm.NewMonitorConnectionState(&conn)
+
+	assert.False(t, state.IsHostUnhealthy())
+
+	// The order the monitor actually uses: mark unhealthy, go inactive, then close.
+	state.SetHostUnhealthy(true)
+	assert.True(t, state.IsHostUnhealthy())
+	assert.True(t, state.ShouldAbort())
+
+	state.SetInactive()
+	assert.False(t, state.ShouldAbort(), "ShouldAbort is cleared by SetInactive")
+	assert.True(t, state.IsHostUnhealthy(), "IsHostUnhealthy must still report the monitor's verdict")
+
+	state.SetHostUnhealthy(false)
+	assert.False(t, state.IsHostUnhealthy())
+}
+
+// The failover gate must act on the monitor's explicit verdict, and must find it
+// through error wrapping - the EFM plugin wraps rather than replaces so the
+// original transport error stays available and each value stays distinct.
+func TestUnavailableHostErrorSurvivesWrapping(t *testing.T) {
+	unavailable := error_util.NewUnavailableHostError("host-1")
+
+	assert.True(t, error_util.IsType(unavailable, error_util.UnavailableHostErrorType))
+
+	// The shape the EFM plugin produces.
+	wrapped := fmt.Errorf("%w: %w", unavailable, net.ErrClosed)
+	assert.True(t, error_util.IsType(wrapped, error_util.UnavailableHostErrorType))
+	assert.True(t, errors.Is(wrapped, net.ErrClosed), "original cause must remain reachable")
+
+	// Also over a bare driver.ErrBadConn, which is the shape pgx produces when it
+	// notices the socket died at an IsClosed guard rather than mid-read.
+	wrappedBadConn := fmt.Errorf("%w: %w", error_util.NewUnavailableHostError("host-1"), driver.ErrBadConn)
+	assert.True(t, error_util.IsType(wrappedBadConn, error_util.UnavailableHostErrorType))
+	assert.True(t, errors.Is(wrappedBadConn, driver.ErrBadConn))
+
+	// Two aborts must not compare equal, or the failover plugin's
+	// !errors.Is(err, lastErrorDealtWith) guard would swallow the second one.
+	assert.False(t, errors.Is(wrappedBadConn, wrapped))
+
+	// An unrelated error must not be mistaken for a monitor abort.
+	assert.False(t, error_util.IsType(driver.ErrBadConn, error_util.UnavailableHostErrorType))
+	assert.False(t, error_util.IsType(net.ErrClosed, error_util.UnavailableHostErrorType))
 }
 
 func TestHostMonitoringServiceImpl(t *testing.T) {

--- a/.test/test/failover_plugin_test.go
+++ b/.test/test/failover_plugin_test.go
@@ -19,7 +19,9 @@ package test
 import (
 	"database/sql/driver"
 	"errors"
+	"fmt"
 	"slices"
+	"syscall"
 	"testing"
 	"time"
 
@@ -100,7 +102,15 @@ type FailoverMockPluginServiceImpl struct {
 	forceRefreshFails      bool
 	isCurrentConnNil       bool
 	isRoleWriter           bool
+	setUnavailableCalls    int
 	*plugin_helpers.PluginServiceImpl
+}
+
+func (t *FailoverMockPluginServiceImpl) SetAvailability(hostAliases map[string]bool, availability host_info_util.HostAvailability) {
+	if availability == host_info_util.UNAVAILABLE {
+		t.setUnavailableCalls++
+	}
+	t.PluginServiceImpl.SetAvailability(hostAliases, availability)
 }
 
 func newFailoverMockPluginServiceImpl(
@@ -249,7 +259,9 @@ func initializeFailoverTest(
 
 	pluginServiceImpl := newFailoverMockPluginServiceImpl(
 		container,
-		mysql_driver.MySQLDriverDialect{},
+		// Must be the constructor: the zero value has a nil errorHandler, so any
+		// IsNetworkError/IsLoginError call through this dialect panics.
+		mysql_driver.NewMySQLDriverDialect(),
 		props,
 		mysqlTestDsn,
 		isInTransaction,
@@ -602,7 +614,9 @@ func TestInvalidateCurrentConnectionInTransaction(t *testing.T) {
 	assert.NoError(t, plugin.InitFailoverMode())
 
 	plugin.InvalidateCurrentConnection()
-	assert.Equal(t, 2, pluginService.isInTransactionCounter)
+	// One call: the state is read once into p.isInTransaction and branched on. It
+	// used to be read twice (once for the branch, once for the assignment).
+	assert.Equal(t, 1, pluginService.isInTransactionCounter)
 	assert.Equal(t, 1, failoverMockConn.closeCounter)
 
 	cleanupFailoverTest()
@@ -640,6 +654,210 @@ func TestExecuteWithFailoverDisabled(t *testing.T) {
 	assert.Equal(t, 1, failoverExecFuncCalls)
 	assert.Equal(t, 0, plugin.calledFailoverCount)
 	assert.Equal(t, 0, failoverMockConn.closeCounter)
+
+	cleanupFailoverTest()
+}
+
+// failoverBadConnExecFunc reproduces what pgx hands the wrapper when it finds the
+// socket already dead: a bare driver.ErrBadConn with the cause discarded.
+func failoverBadConnExecFunc() (any, any, bool, error) {
+	failoverExecFuncCalls++
+	return nil, nil, false, driver.ErrBadConn
+}
+
+// driver.ErrBadConn is database/sql's stale-pooled-conn signal, so on its own it
+// must not fail over. But a connection bound to an open transaction is actively in
+// use and never reaped for pool hygiene, so ErrBadConn on a CLOSED connection
+// inside a transaction can only be the server or network killing a live
+// connection. Only that combination should fail over.
+func TestExecuteBadConnFailsOverOnlyWhenConnDeadInTransaction(t *testing.T) {
+	props := map[string]string{
+		property_util.ENABLE_CONNECT_FAILOVER.Name: "false",
+		property_util.DRIVER_PROTOCOL.Name:         "mysql",
+	}
+
+	testCases := []struct {
+		name           string
+		inTransaction  bool
+		connClosed     bool
+		expectFailover bool
+	}{
+		{"dead conn in transaction fails over", true, true, true},
+		{"live conn in transaction does not", true, false, false},
+		{"dead conn outside a transaction does not", false, true, false},
+		{"live conn outside a transaction does not", false, false, false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			setupFailoverTest()
+			failoverMockConn.isInvalid = tc.connClosed
+			defer func() { failoverMockConn.isInvalid = false }()
+
+			plugin, pluginService := initializeFailoverTest(t, props, tc.inTransaction, true, false, false, false, false)
+			assert.NoError(t, plugin.InitFailoverMode())
+			// isFailoverEnabled requires a non-empty host list; without this the gate
+			// short-circuits before ever looking at the error.
+			pluginService.AllHosts = []*host_info_util.HostInfo{failoverHost1, failoverHost2}
+
+			_, _, _, err := plugin.Execute(nil, utils.CONN_QUERY_CONTEXT, failoverBadConnExecFunc)
+
+			if tc.expectFailover {
+				// In a transaction the wrapper cannot know whether the transaction
+				// committed, so it reports resolution-unknown rather than success.
+				assert.True(t, error_util.IsType(err, error_util.TransactionResolutionUnknownErrorType),
+					"expected a failover error, got %v", err)
+			} else {
+				assert.True(t, errors.Is(err, driver.ErrBadConn),
+					"expected the raw ErrBadConn to pass through, got %v", err)
+			}
+
+			cleanupFailoverTest()
+		})
+	}
+}
+
+// lastErrorDealtWith must not latch. It guards against failing over twice on one
+// error as it unwinds, but two independent driver.ErrBadConn occurrences are the
+// same value, so errors.Is cannot tell them apart. Clearing it on a successful
+// call keeps a later genuine failure from being silently swallowed.
+func TestExecuteRepeatBadConnFailoverIsNotSwallowed(t *testing.T) {
+	setupFailoverTest()
+	failoverMockConn.isInvalid = true
+	defer func() { failoverMockConn.isInvalid = false }()
+
+	props := map[string]string{
+		property_util.ENABLE_CONNECT_FAILOVER.Name: "false",
+		property_util.DRIVER_PROTOCOL.Name:         "mysql",
+	}
+	plugin, pluginService := initializeFailoverTest(t, props, true, true, false, false, false, false)
+	assert.NoError(t, plugin.InitFailoverMode())
+	pluginService.AllHosts = []*host_info_util.HostInfo{failoverHost1, failoverHost2}
+
+	_, _, _, first := plugin.Execute(nil, utils.CONN_QUERY_CONTEXT, failoverBadConnExecFunc)
+	assert.True(t, error_util.IsType(first, error_util.TransactionResolutionUnknownErrorType),
+		"first failure should fail over, got %v", first)
+
+	// A successful call closes the propagating-error window.
+	_, _, _, ok := plugin.Execute(nil, utils.CONN_QUERY_CONTEXT, failoverExecFunc)
+	assert.NoError(t, ok)
+
+	_, _, _, second := plugin.Execute(nil, utils.CONN_QUERY_CONTEXT, failoverBadConnExecFunc)
+	assert.True(t, error_util.IsType(second, error_util.TransactionResolutionUnknownErrorType),
+		"second failure must also fail over, not be swallowed by lastErrorDealtWith, got %v", second)
+
+	cleanupFailoverTest()
+}
+
+// The ErrBadConn gate must read the LIVE transaction state only. p.isInTransaction
+// is only ever assigned true, so if the gate consulted it a single transactional
+// failover would make every later ErrBadConn look transactional and fail over
+// outside a transaction.
+func TestExecuteBadConnGateDoesNotLatchTransactionState(t *testing.T) {
+	setupFailoverTest()
+	failoverMockConn.isInvalid = true
+	defer func() { failoverMockConn.isInvalid = false }()
+
+	props := map[string]string{
+		property_util.ENABLE_CONNECT_FAILOVER.Name: "false",
+		property_util.DRIVER_PROTOCOL.Name:         "mysql",
+	}
+	// Start in a transaction so the first failure latches p.isInTransaction.
+	plugin, pluginService := initializeFailoverTest(t, props, true, true, false, false, false, false)
+	assert.NoError(t, plugin.InitFailoverMode())
+	pluginService.AllHosts = []*host_info_util.HostInfo{failoverHost1, failoverHost2}
+
+	_, _, _, first := plugin.Execute(nil, utils.CONN_QUERY_CONTEXT, failoverBadConnExecFunc)
+	assert.True(t, error_util.IsType(first, error_util.TransactionResolutionUnknownErrorType),
+		"in-transaction failure should fail over, got %v", first)
+
+	// The transaction is over. A dead connection outside a transaction is
+	// indistinguishable from ordinary pool staleness, so it must NOT fail over.
+	pluginService.inTransactionResult = false
+	_, _, _, ok := plugin.Execute(nil, utils.CONN_QUERY_CONTEXT, failoverExecFunc)
+	assert.NoError(t, ok)
+
+	_, _, _, after := plugin.Execute(nil, utils.CONN_QUERY_CONTEXT, failoverBadConnExecFunc)
+	assert.True(t, errors.Is(after, driver.ErrBadConn),
+		"outside a transaction ErrBadConn must pass through untouched, got %v", after)
+
+	cleanupFailoverTest()
+}
+
+// p.isInTransaction snapshots the pre-failover transaction state because the
+// connection switch clears the live flag. It must be re-snapshotted and consumed
+// each time, or a transactional failover would latch it on and every later
+// non-transactional failover would be misreported as resolution-unknown.
+func TestFailoverInTransactionThenNotDoesNotMisreport(t *testing.T) {
+	setupFailoverTest()
+
+	props := map[string]string{
+		property_util.ENABLE_CONNECT_FAILOVER.Name: "false",
+		property_util.DRIVER_PROTOCOL.Name:         "mysql",
+	}
+	plugin, pluginService := initializeFailoverTest(t, props, true, true, false, false, false, false)
+	assert.NoError(t, plugin.InitFailoverMode())
+
+	// A transactional failover: the caller cannot know whether the transaction
+	// committed, so resolution-unknown is correct.
+	first := plugin.Failover()
+	assert.Equal(t, error_util.TransactionResolutionUnknownError, first)
+
+	// A later failover with no transaction open must report plain success.
+	pluginService.inTransactionResult = false
+	second := plugin.Failover()
+	assert.Equal(t, error_util.FailoverSuccessError, second,
+		"a non-transactional failover must not inherit the previous transaction state")
+
+	cleanupFailoverTest()
+}
+
+// A bare ErrBadConn does not say why the connection died, so the host must not be
+// durably penalised on that guess - unlike an error that positively identifies a
+// transport or host fault.
+func TestBadConnFailoverDoesNotMarkHostUnavailable(t *testing.T) {
+	setupFailoverTest()
+	failoverMockConn.isInvalid = true
+	defer func() { failoverMockConn.isInvalid = false }()
+
+	props := map[string]string{
+		property_util.ENABLE_CONNECT_FAILOVER.Name: "false",
+		property_util.DRIVER_PROTOCOL.Name:         "mysql",
+	}
+	plugin, pluginService := initializeFailoverTest(t, props, true, true, false, false, false, false)
+	assert.NoError(t, plugin.InitFailoverMode())
+	pluginService.AllHosts = []*host_info_util.HostInfo{failoverHost1, failoverHost2}
+
+	_, _, _, err := plugin.Execute(nil, utils.CONN_QUERY_CONTEXT, failoverBadConnExecFunc)
+	assert.True(t, error_util.IsType(err, error_util.TransactionResolutionUnknownErrorType),
+		"expected failover, got %v", err)
+	assert.Equal(t, 0, pluginService.setUnavailableCalls,
+		"ErrBadConn does not identify a host fault, so the host must not be marked UNAVAILABLE")
+
+	cleanupFailoverTest()
+}
+
+// Contrast with TestBadConnFailoverDoesNotMarkHostUnavailable: an error that
+// positively identifies a transport fault still marks the host unavailable.
+func TestNetworkErrorFailoverMarksHostUnavailable(t *testing.T) {
+	setupFailoverTest()
+
+	props := map[string]string{
+		property_util.ENABLE_CONNECT_FAILOVER.Name: "false",
+		property_util.DRIVER_PROTOCOL.Name:         "mysql",
+	}
+	plugin, pluginService := initializeFailoverTest(t, props, true, true, false, false, false, false)
+	assert.NoError(t, plugin.InitFailoverMode())
+	pluginService.AllHosts = []*host_info_util.HostInfo{failoverHost1, failoverHost2}
+
+	_, _, _, err := plugin.Execute(nil, utils.CONN_QUERY_CONTEXT, func() (any, any, bool, error) {
+		failoverExecFuncCalls++
+		return nil, nil, false, fmt.Errorf("write tcp: %w", syscall.EPIPE)
+	})
+	assert.True(t, error_util.IsType(err, error_util.TransactionResolutionUnknownErrorType),
+		"expected failover, got %v", err)
+	assert.Positive(t, pluginService.setUnavailableCalls,
+		"a positively identified transport fault should mark the host UNAVAILABLE")
 
 	cleanupFailoverTest()
 }

--- a/.test/test/pgx_driver_dialect_test.go
+++ b/.test/test/pgx_driver_dialect_test.go
@@ -97,10 +97,43 @@ func TestPgxErrorHandler_CallerCancellationAndStaleConn(t *testing.T) {
 	})
 }
 
-func TestPgxErrorHandler_LocalCloseNotNetwork(t *testing.T) {
+// net.ErrClosed and pgconn.ErrConnClosed both describe a closed connection but
+// mean opposite things. ErrConnClosed is a use-after-close: the operation never
+// reached the wire. net.ErrClosed is an abort of a read already in flight, which
+// in this wrapper only happens when EFM or the connection tracker deliberately
+// kills a connection to a host it judged unhealthy - the only failover signal
+// available when the network path is blackholed and no RST/FIN/EOF ever arrives.
+func TestPgxErrorHandler_ClosedConnectionDistinction(t *testing.T) {
 	h := &pgx_driver.PgxErrorHandler{}
-	assert.False(t, h.IsNetworkError(net.ErrClosed))
-	assert.False(t, h.IsNetworkError(fmt.Errorf("read tcp: %w", net.ErrClosed)))
+
+	t.Run("net.ErrClosed (in-flight abort) IS a network error", func(t *testing.T) {
+		assert.True(t, h.IsNetworkError(net.ErrClosed))
+		assert.True(t, h.IsNetworkError(fmt.Errorf("read tcp: %w", net.ErrClosed)))
+		// The shape pgx actually produces when the socket is closed mid-read.
+		assert.True(t, h.IsNetworkError(&net.OpError{
+			Op: "read", Net: "tcp", Err: net.ErrClosed,
+		}))
+	})
+
+	t.Run("pgconn.ErrConnClosed (use-after-close) is NOT a network error", func(t *testing.T) {
+		assert.True(t, errors.Is(pgconn.ErrConnClosed, pgconn.ErrConnClosed))
+		assert.False(t, h.IsNetworkError(pgconn.ErrConnClosed))
+		assert.False(t, h.IsNetworkError(fmt.Errorf("query failed: %w", pgconn.ErrConnClosed)))
+	})
+}
+
+// Pins the invariant that dealWithError's !errors.Is(err, lastErrorDealtWith)
+// guard (failover_plugin.go) does not swallow consecutive EFM aborts. Each abort
+// produces a distinct *net.OpError, so errors.Is between two of them must be
+// false - unlike a bare sentinel, which compares equal to itself and would make
+// the second and every later occurrence be silently skipped.
+func TestPgxErrorHandler_DistinctOpErrorsAreNotEqual(t *testing.T) {
+	first := &net.OpError{Op: "read", Net: "tcp", Err: net.ErrClosed}
+	second := &net.OpError{Op: "read", Net: "tcp", Err: net.ErrClosed}
+
+	assert.False(t, errors.Is(second, first))
+	assert.True(t, errors.Is(first, net.ErrClosed))
+	assert.True(t, errors.Is(second, net.ErrClosed))
 }
 
 func TestPgxErrorHandler_TypedTransportSentinels(t *testing.T) {

--- a/awssql/plugins/efm/host_monitoring_plugin.go
+++ b/awssql/plugins/efm/host_monitoring_plugin.go
@@ -18,6 +18,7 @@ package efm
 
 import (
 	"database/sql/driver"
+	"fmt"
 	"log/slog"
 	"slices"
 
@@ -122,6 +123,13 @@ func (b *HostMonitorConnectionPlugin) Execute(
 			return
 		}
 		wrappedReturnValue, wrappedReturnValue2, wrappedOk, wrappedErr = executeFunc()
+
+		// If the monitor declared this host unhealthy and aborted the connection.
+		// Wrap the original connection error in an NewUnavailableHostError so failover plugin could better handle it.
+		if wrappedErr != nil && monitorState != nil && monitorState.IsHostUnhealthy() {
+			wrappedErr = fmt.Errorf("%w: %w",
+				error_util.NewUnavailableHostError(monitoringHostInfo.Host), wrappedErr)
+		}
 
 		if monitorState != nil {
 			b.monitorService.StopMonitoring(monitorState, b.servicesContainer.GetPluginService().GetCurrentConnection())

--- a/awssql/plugins/efm/host_monitoring_service.go
+++ b/awssql/plugins/efm/host_monitoring_service.go
@@ -221,6 +221,24 @@ func (m *MonitorConnectionState) SetInactive() {
 	m.connToAbortRef = weak.Make((*driver.Conn)(nilPointer))
 }
 
+// IsHostUnhealthy reports whether the monitor declared this host unhealthy while
+// the state was active, regardless of whether the connection reference has since
+// been cleared. Callers use this after executeFunc returns to tell a deliberate
+// monitor-initiated abort apart from an unrelated failure: the transport error a
+// driver produces for an abort is not reliably distinguishable on its own (pgx
+// yields either net.ErrClosed or a bare driver.ErrBadConn depending on where it
+// notices the socket is gone).
+//
+// Note this is deliberately NOT ShouldAbort: the monitor calls SetInactive before
+// closing the connection, so ShouldAbort's connToAbortRef check is already false
+// by the time the aborted call returns.
+func (m *MonitorConnectionState) IsHostUnhealthy() bool {
+	m.hostHealthLock.RLock()
+	defer m.hostHealthLock.RUnlock()
+
+	return m.hostUnhealthy
+}
+
 func (m *MonitorConnectionState) ShouldAbort() bool {
 	m.connLock.RLock()
 	m.hostHealthLock.RLock()

--- a/awssql/plugins/failover_plugin.go
+++ b/awssql/plugins/failover_plugin.go
@@ -275,6 +275,12 @@ func (p *FailoverPlugin) Execute(
 	var err error
 	if wrappedErr != nil {
 		err = p.handler.dealWithError(wrappedErr)
+	} else {
+		// lastErrorDealtWith exists to stop one error being failed over twice as it
+		// unwinds through nested calls. Clear it once a call succeeds.
+		// Two independent driver.ErrBadConn occurrences are the same value,
+		// so errors.Is cannot tell a repeat failure from a re-delivery of the one already handled.
+		p.lastErrorDealtWith = nil
 	}
 
 	if err != nil {
@@ -293,18 +299,21 @@ func (p *FailoverPlugin) canDirectExecute(methodName string) bool {
 }
 
 func (p *FailoverPlugin) returnFailoverSuccessError() error {
-	if p.isInTransaction || p.servicesContainer.GetPluginService().IsInTransaction() {
+	inTransaction := p.isInTransaction || p.servicesContainer.GetPluginService().IsInTransaction()
+
+	if inTransaction {
 		p.servicesContainer.GetPluginService().SetInTransaction(false)
+		p.isInTransaction = false
 
 		// "Transaction resolution unknown. Please re-configure session state if required and try restarting transaction."
 		message := error_util.GetMessage("Failover.transactionResolutionUnknownError")
 		slog.Info(message)
 		return error_util.TransactionResolutionUnknownError
-	} else {
-		// "The active SQL connection has changed due to a connection failure. Please re-configure session state if required."
-		slog.Warn(error_util.GetMessage("Failover.connectionChangedError"))
-		return error_util.FailoverSuccessError
 	}
+
+	// "The active SQL connection has changed due to a connection failure. Please re-configure session state if required."
+	slog.Warn(error_util.GetMessage("Failover.connectionChangedError"))
+	return error_util.FailoverSuccessError
 }
 
 func (p *FailoverPlugin) FailoverWriter() error {
@@ -581,8 +590,9 @@ func (p *FailoverPlugin) InvalidateCurrentConnection() {
 		return
 	}
 
-	if p.servicesContainer.GetPluginService().IsInTransaction() {
-		p.isInTransaction = p.servicesContainer.GetPluginService().IsInTransaction()
+	// Snapshot the live transaction state before the connection switch clears it.
+	p.isInTransaction = p.servicesContainer.GetPluginService().IsInTransaction()
+	if p.isInTransaction {
 		utils.Rollback(conn, p.servicesContainer.GetPluginService().GetCurrentTx())
 	}
 
@@ -597,11 +607,48 @@ func (p *FailoverPlugin) shouldErrorTriggerConnectionSwitch(err error) bool {
 		return false
 	}
 
+	// UnavailableHostErrorType is thrown when the host monitoring plugin deliberately marked a host as unhealthy and
+	// has aborted this connection to it. Trigger failover directly.
+	if error_util.IsType(err, error_util.UnavailableHostErrorType) {
+		return true
+	}
+
+	// database/sql uses driver.ErrBadConn as its stale-pooled-connection signal, so
+	// it must never trigger failover on its own. But pgx also returns a *bare*
+	// ErrBadConn - with the underlying cause discarded - when it finds the socket
+	// already dead at its IsClosed guard or via pgconn.SafeToRetry, so a genuine
+	// transport failure is indistinguishable from pool hygiene by error value
+	// alone. Connection state disambiguates it: a connection bound to an open
+	// transaction is actively in use and is never reaped for pool hygiene, and
+	// database/sql does not retry ErrBadConn inside a transaction, so it reaches
+	// the caller verbatim. ErrBadConn + closed connection + open transaction can
+	// therefore only mean the server or network killed a live connection.
+	if errors.Is(err, driver.ErrBadConn) {
+		return p.isCurrentConnectionDeadInTransaction()
+	}
+
 	pluginService := p.servicesContainer.GetPluginService()
 	if pluginService.IsNetworkError(err) {
 		return true
 	}
 	return p.FailoverMode == MODE_STRICT_WRITER && pluginService.IsReadOnlyError(err)
+}
+
+func (p *FailoverPlugin) isCurrentConnectionDeadInTransaction() bool {
+	pluginService := p.servicesContainer.GetPluginService()
+	// Consults the live transaction state, not p.isInTransaction: this gate runs
+	// before InvalidateCurrentConnection takes that snapshot, so at this point the
+	// field describes a previous failover, not the current one.
+	if !pluginService.IsInTransaction() {
+		return false
+	}
+
+	conn := pluginService.GetCurrentConnection()
+	return conn != nil && pluginService.GetTargetDriverDialect().IsClosed(conn)
+}
+
+func (p *FailoverPlugin) shouldMarkCurrentHostUnavailable(err error) bool {
+	return !errors.Is(err, driver.ErrBadConn)
 }
 
 func (p *FailoverPlugin) createConnectionForHost(hostInfo *host_info_util.HostInfo) (driver.Conn, error) {
@@ -659,7 +706,10 @@ func (h *rdsFailoverHandler) dealWithError(err error) error {
 			if e != nil {
 				return e
 			}
-			p.servicesContainer.GetPluginService().SetAvailability(currentHost.Aliases, host_info_util.UNAVAILABLE)
+			// GetCurrentHostInfo can return a nil host with a nil error.
+			if currentHost != nil && p.shouldMarkCurrentHostUnavailable(err) {
+				p.servicesContainer.GetPluginService().SetAvailability(currentHost.Aliases, host_info_util.UNAVAILABLE)
+			}
 			e = h.failover()
 			if e != nil {
 				return e

--- a/awssql/plugins/gdb_failover_plugin.go
+++ b/awssql/plugins/gdb_failover_plugin.go
@@ -176,7 +176,10 @@ func (h *globalDbFailoverHandler) dealWithError(err error) error {
 			if e != nil {
 				return e
 			}
-			p.servicesContainer.GetPluginService().SetAvailability(currentHost.Aliases, host_info_util.UNAVAILABLE)
+			// GetCurrentHostInfo can return a nil host with a nil error.
+			if currentHost != nil && p.shouldMarkCurrentHostUnavailable(err) {
+				p.servicesContainer.GetPluginService().SetAvailability(currentHost.Aliases, host_info_util.UNAVAILABLE)
+			}
 			e = h.failover()
 			if e != nil {
 				return e

--- a/bun-pg-driver/bun_error_handler.go
+++ b/bun-pg-driver/bun_error_handler.go
@@ -21,6 +21,7 @@ import (
 	"database/sql/driver"
 	"errors"
 	"io"
+	"net"
 	"slices"
 	"strings"
 	"syscall"
@@ -69,6 +70,17 @@ func (h *BunPgErrorHandler) IsNetworkError(err error) bool {
 	// server/network faults surface as SQLSTATE 08xxx/57P01 or raw I/O errors.
 	if errors.Is(err, driver.ErrBadConn) {
 		return false
+	}
+
+	// net.ErrClosed means a read that was ALREADY IN FLIGHT had its socket
+	// closed out from under it by another goroutine. In this wrapper that only
+	// happens when we deliberately abort a connection whose host we just judged
+	// unhealthy: EFM's monitor (plugins/efm/host_monitor.go) or the connection
+	// tracker (plugins/connection_tracker/opened_connection_tracker.go). A
+	// blackholed network path (hung instance, partition, security-group change)
+	// yields no RST/FIN/EOF, so this is the only failover signal available.
+	if errors.Is(err, net.ErrClosed) {
+		return true
 	}
 
 	// Typed transport faults; substrings below are a fallback.

--- a/bun-pg-driver/bun_error_handler_test.go
+++ b/bun-pg-driver/bun_error_handler_test.go
@@ -37,8 +37,15 @@ func TestBunPgErrorHandler_IsNetworkError(t *testing.T) {
 		assert.True(t, h.IsNetworkError(fmt.Errorf("write: broken pipe")))
 	})
 
-	t.Run("net.ErrClosed (local close) is not a network error", func(t *testing.T) {
-		assert.False(t, h.IsNetworkError(net.ErrClosed))
+	// An in-flight read whose socket was aborted by EFM or the connection
+	// tracker surfaces as net.ErrClosed, and is the only failover signal
+	// available when the network path is blackholed. Matched by sentinel, not
+	// by message text - an unwrapped string that merely reads the same is not
+	// the sentinel and stays unclassified.
+	t.Run("net.ErrClosed (in-flight abort) IS a network error", func(t *testing.T) {
+		assert.True(t, h.IsNetworkError(net.ErrClosed))
+		assert.True(t, h.IsNetworkError(fmt.Errorf("read tcp: %w", net.ErrClosed)))
+		assert.True(t, h.IsNetworkError(&net.OpError{Op: "read", Net: "tcp", Err: net.ErrClosed}))
 		assert.False(t, h.IsNetworkError(fmt.Errorf("read: use of closed network connection")))
 	})
 

--- a/pgx-driver/pgx_error_handler.go
+++ b/pgx-driver/pgx_error_handler.go
@@ -21,6 +21,7 @@ import (
 	"database/sql/driver"
 	"errors"
 	"io"
+	"net"
 	"slices"
 	"strings"
 	"syscall"
@@ -69,6 +70,24 @@ func (p *PgxErrorHandler) IsNetworkError(err error) bool {
 	// cached conn and retries on a fresh one. Not a network fault.
 	if errors.Is(err, driver.ErrBadConn) {
 		return false
+	}
+	// pgconn.ErrConnClosed means the operation never reached the wire: the conn
+	// was already closed (by the caller, the pool, or a prior teardown). pgx
+	// surfaces it wrapped in connLockError{"conn closed"}. Not a fault.
+	if errors.Is(err, pgconn.ErrConnClosed) {
+		return false
+	}
+
+	// net.ErrClosed means a read that was ALREADY IN FLIGHT had its socket
+	// closed out from under it by another goroutine. In this wrapper that only
+	// happens when we deliberately abort a connection whose host we just judged
+	// unhealthy: EFM's monitor (plugins/efm/host_monitor.go) or the connection
+	// tracker (plugins/connection_tracker/opened_connection_tracker.go). A
+	// blackholed network path (hung instance, partition, security-group change)
+	// yields no RST/FIN/EOF, so this is the only failover signal available.
+	// Contrast pgconn.ErrConnClosed above, which is the use-after-close case.
+	if errors.Is(err, net.ErrClosed) {
+		return true
 	}
 
 	// Typed transport faults; substrings below are a fallback.


### PR DESCRIPTION
### Summary

Fail over on two connection failures that previously returned the raw error to the caller: an EFM monitor aborting a connection to an unhealthy host, and an in-transaction connection killed by the server or network.

### Description

In both cases `shouldErrorTriggerConnectionSwitch` could not classify the error and returned `false`, so no failover was attempted and the caller got the driver error. Fixes are in the driver error handlers and in the failover gate.

**`net.ErrClosed` was treated as a local close** (`pgx-driver/pgx_error_handler.go`, `bun-pg-driver/bun_error_handler.go`)

It is not. It means an in-flight read had its socket closed by another goroutine, which in this wrapper only happens when EFM's monitor or the connection tracker aborts a connection to a host judged unhealthy. If the network path is blackholed there is no RST/FIN/EOF, so this is the only available failover signal, and ignoring it meant a hung instance never triggered failover. Now classified as a network error, matched on the sentinel via `errors.Is` so a bare `use of closed network connection` string still does not match.

`pgconn.ErrConnClosed` is now explicitly excluded, so the use-after-close case (operation never reached the wire) is not swept in with the above.

**An EFM abort was not identifiable from the transport error** (`awssql/plugins/efm/`)

pgx returns either `net.ErrClosed` or a bare `driver.ErrBadConn` depending on where it notices the socket is gone, so the monitor's verdict was unrecoverable by the time the aborted call returned. `HostMonitorConnectionPlugin.Execute` now wraps the error in `UnavailableHostError` when the monitor declared the host unhealthy, and the gate treats `UnavailableHostErrorType` as a failover trigger. Wrapping keeps the original cause reachable and each abort a distinct value. This needs a new `MonitorConnectionState.IsHostUnhealthy` rather than `ShouldAbort`, because the monitor calls `SetInactive` before closing the connection, so `ShouldAbort`'s `connToAbortRef` check is already false once the call returns.

**`driver.ErrBadConn` could not be told apart from pool staleness** (`awssql/plugins/failover_plugin.go`)

`database/sql` uses it as its stale-pooled-connection signal, but pgx also returns a bare `ErrBadConn` with the cause discarded when it finds the socket already dead at its `IsClosed` guard or via `pgconn.SafeToRetry`. A server or network kill of a live connection was therefore indistinguishable from pool hygiene and never failed over.

Connection state disambiguates it: a connection bound to an open transaction is in use and is not reaped for pool hygiene, and `database/sql` does not retry `ErrBadConn` inside a transaction, so it reaches the caller as-is. `ErrBadConn` plus a closed connection plus an open transaction now fails over; anything else passes through unchanged. The host is not marked `UNAVAILABLE` in this case (`shouldMarkCurrentHostUnavailable`), since the error does not identify a host fault; errors that do still mark it.

**`lastErrorDealtWith` latched** (`awssql/plugins/failover_plugin.go`)

It prevents one error being failed over twice as it unwinds, but two independent `driver.ErrBadConn` occurrences are the same value, so `errors.Is` cannot tell a repeat failure from a re-delivery and the second genuine failure was dropped. Now cleared on a successful call.

**`p.isInTransaction` latched** (`awssql/plugins/failover_plugin.go`)

It was only ever set to `true`, so after one transactional failover every later non-transactional failover reported `TransactionResolutionUnknownError` instead of `FailoverSuccessError`. `InvalidateCurrentConnection` now snapshots the live state before the connection switch clears it and `returnFailoverSuccessError` consumes the snapshot. The `ErrBadConn` gate reads the live plugin-service state rather than the snapshot, since it runs before the snapshot is taken.

Also fixes `GetCurrentHostInfo` returning a nil host with a nil error in both `rdsFailoverHandler` and `globalDbFailoverHandler`, and switches the failover test setup to `mysql_driver.NewMySQLDriverDialect()`, whose zero value has a nil `errorHandler` and panics on `IsNetworkError`/`IsLoginError`.

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
